### PR TITLE
Consolidating Treaty Ports Decisions

### DIFF
--- a/TGC/decisions/Treaty_Ports.txt
+++ b/TGC/decisions/Treaty_Ports.txt
@@ -86,7 +86,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			1498 = { secede_province = THIS change_controller = THIS }
+			1498 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
@@ -136,7 +136,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			1496 = { secede_province = THIS change_controller = THIS }
+			1496 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 		}
@@ -173,7 +173,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			1538 = { secede_province = THIS change_controller = THIS }
+			1538 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
@@ -213,7 +213,8 @@ political_decisions = {
 	qingdao_treaty_port = {
 		picture = qingdao_china
 		potential = {
-			OR = { 
+			OR = {
+				has_global_flag = colonial_railroading_disabled 
 				tag = NGF
 				tag = GER
 				tag = GCF
@@ -228,7 +229,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			1566 = { secede_province = THIS change_controller = THIS }
+			1566 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
@@ -327,7 +328,10 @@ political_decisions = {
 			has_country_modifier = negotiating_treaty
 			1569 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
-			tag = ENG
+			OR = {
+				has_global_flag = colonial_railroading_disabled
+				tag = ENG
+			}
 		}
 		
 		allow = {
@@ -335,7 +339,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			1569 = { secede_province = THIS change_controller = THIS }
+			1569 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
@@ -549,9 +553,13 @@ political_decisions = {
 	kwangchowan_treaty_port = {
 		picture = kwangchowan_china
 		potential = {
-			primary_culture = french
-			is_greater_power = yes
-			capital = 425
+			OR = {
+				has_global_flag = colonial_railroading_disabled
+				AND = {
+					primary_culture = french
+					capital = 425
+				}
+			}
 			has_country_modifier = negotiating_treaty
 			2632 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
@@ -562,7 +570,7 @@ political_decisions = {
 		
 		effect = {
 			remove_country_modifier = negotiating_treaty
-			2632 = { secede_province = THIS change_controller = THIS }
+			2632 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
@@ -604,7 +612,7 @@ political_decisions = {
 					2562 = { owner = { civilized = no truce_with = THIS } }
 				}
 			}
-		}
+	}
 		
 	ningbo_treaty_port = {
 		picture = ningbo_china
@@ -820,6 +828,7 @@ political_decisions = {
 		
 		ai_will_do = { factor = 1 }
 	}
+
 	liaodong_lease = {
 		picture = port_arthur
 		potential = {


### PR DESCRIPTION
Choosing to disable colonial railroading now also removes the country limitations on certain treaty ports.
All Chinese treaty ports will immediately get the Treaty Port province modifier instead of just some of them.
Removed the great power requirement for France when taking Kwangchowan as no other treaty port has this limitation.
Minor formatting.