### PR TITLE
Renaming Decisions

### DIFF
--- a/TGC/decisions/Renaming-Decisions-Europe.txt
+++ b/TGC/decisions/Renaming-Decisions-Europe.txt
@@ -1,6 +1,7 @@
-political_decisions = { 
+political_decisions = {
 ### AUSTRIA ###
 ## Burgenland ##
+
 	burgenland_rename = {
 		picture = gtfo
 		potential = {
@@ -21,7 +22,8 @@ political_decisions = {
 		}
 
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
 
 		effect = {
@@ -69,29 +71,33 @@ political_decisions = {
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Transdanubia ##
+
 	transdanubia_rename_hun = {
 		picture = gtfo
 		potential = {
 			OR = {
 				primary_culture = hungarian
 				tag = KUK
+				tag = DNB
 			}
 			owns = 639
 			NOT = { has_global_flag = transdanubia_rename_hun }
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = transdanubia_rename_hun
-			639 = { 
-				change_province_name = "Zalaegerszeg" 
+			639 = {
+				change_province_name = "Zalaegerszeg"
 				state_scope = { change_region_name = "Dunántúl" }
 			}
 			640 = { change_province_name = "Pécs" }
@@ -101,7 +107,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	transdanubia_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -110,26 +116,60 @@ political_decisions = {
 			owns = 639
 			has_global_flag = transdanubia_rename_hun
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = transdanubia_rename_hun
-			639 = { 
-				change_province_name = "Egersee" 
+			639 = {
+				change_province_name = "Egersee"
 				state_scope = { change_region_name = "Transdanubien" }
 			}
 			640 = { change_province_name = "Fünfkirchen" }
 			642 = { change_province_name = "Raab" }
 			643 = { change_province_name = "Stuhlweißenburg" }
 			644 = { change_province_name = "Ruppertsburg" }
+			3283 = { change_province_name = "Branau" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
-## Bohemia-Moravia ##	
+	transdanubia_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 639
+			NOT = { has_global_flag = transdanubia_rename_tur }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = transdanubia_rename_tur
+			clr_global_flag = transdanubia_rename_hun
+			639 = {
+				change_province_name = "Ersekiyvar"
+				state_scope = { change_region_name = "Egri Eyalet" }
+			}
+			640 = { change_province_name = "Mohaç" }
+			642 = { change_province_name = "Yanikkale" }
+			643 = { change_province_name = "Istolni Belgrad" }
+			644 = { change_province_name = "Kaposvar" }
+			3283 = { change_province_name = "Baranya" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Bohemia-Moravia ##
+
 	bohemia_rename_czh = {
 		picture = gtfo
 		potential = {
@@ -142,14 +182,14 @@ political_decisions = {
 			owns = 625 #Prague
 			NOT = { has_global_flag = bohemia_rename_czh }
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bohemia_rename_czh
-			prestige = 2
 			625 = {
 				change_province_name = "Praha"
 				state_scope = { change_region_name = "Cechy-Morava" }
@@ -158,9 +198,10 @@ political_decisions = {
 			629 = { change_province_name = "Plzen" }
 			631 = { change_province_name = "Brno" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	bohemia_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -169,11 +210,12 @@ political_decisions = {
 			owns = 625 #Prague
 			has_global_flag = bohemia_rename_czh
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = bohemia_rename_czh
 			625 = {
@@ -184,10 +226,12 @@ political_decisions = {
 			629 = { change_province_name = "Pilsen" }
 			631 = { change_province_name = "Brünn" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 ## Sudetenland ##
+
 	sudetes_rename_czh = {
 		picture = gtfo
 		potential = {
@@ -200,14 +244,14 @@ political_decisions = {
 			owns = 627 #Karlsbad
 			NOT = { has_global_flag = sudetes_rename_czh }
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = sudetes_rename_czh
-			prestige = 2
 			627 = {
 				change_province_name = "Karlovy Vary"
 				state_scope = { change_region_name = "Sudety" }
@@ -216,9 +260,10 @@ political_decisions = {
 			630 = { change_province_name = "Budejovice" }
 			632 = { change_province_name = "Olomouc" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	sudetes_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -227,11 +272,12 @@ political_decisions = {
 			owns = 627 #Karlsbad
 			has_global_flag = sudetes_rename_czh
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = sudetes_rename_czh
 			627 = {
@@ -242,10 +288,12 @@ political_decisions = {
 			630 = { change_province_name = "Budweis" }
 			632 = { change_province_name = "Olmütz" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Slovakia ##
+
 	slovakia_rename_czhslo = {
 		picture = gtfo
 		potential = {
@@ -254,17 +302,18 @@ political_decisions = {
 				is_culture_group = czecho_slovak_culture_group
 				tag = SLV
 				tag = CZH
+				tag = WSF
 				AND = {
 					tag = DNB
 					accepted_culture = slovak
 				}
 			}
 			OR = {
-				AND = { 
-					owns = 633 
+				AND = {
+					owns = 633
 					NOT = { has_global_flag = slovakia_rename_czhslopres }
 				}
-				AND = { 
+				AND = {
 					owns = 634
 					owns = 636
 					owns = 638
@@ -272,37 +321,40 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 633 }
-			633 = { 
 				change_province_name = "Prešporok" #Bratislava after 1918
-				state_scope = { change_region_name = "Slovensko" }
-			}
-				owner = { set_global_flag = slovakia_rename_czhslopres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres_1918 }
-				owner = { clr_global_flag = slovakia_rename_hunpres }
+				owner = {
+					set_global_flag = slovakia_rename_czhslopres
+					clr_global_flag = slovakia_rename_czhslopres_1918
+					clr_global_flag = slovakia_rename_hunpres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 634 }
-			634 = { change_province_name = "Trencín" }
-			636 = { change_province_name = "Banská Bystrica" }
-			638 = { change_province_name = "Prešov" }
-			3310 = { change_province_name = "Vyšná Jablonka" }
-				owner = { set_global_flag = slovakia_rename_czhslo }
-				owner = { clr_global_flag = slovakia_rename_czhslo_1918 }
-				owner = { clr_global_flag = slovakia_rename_hun }
+				change_province_name = "Trencín"
+				state_scope = { change_region_name = "Slovensko" }
+				636 = { change_province_name = "Banská Bystrica" }
+				638 = { change_province_name = "Prešov" }
+				3310 = { change_province_name = "Vyšná Jablonka" }
+				owner = {
+					set_global_flag = slovakia_rename_czhslo
+					clr_global_flag = slovakia_rename_czhslo_1918
+					clr_global_flag = slovakia_rename_hun
+				}
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	slovakia_rename_czhslo_1918 = {
 		picture = gtfo
 		potential = {
@@ -311,17 +363,18 @@ political_decisions = {
 				is_culture_group = czecho_slovak_culture_group
 				tag = SLV
 				tag = CZH
+				tag = WSF
 				AND = {
 					tag = DNB
 					accepted_culture = slovak
 				}
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 633
 					NOT = { has_global_flag = slovakia_rename_czhslopres_1918 }
 				}
-				AND = { 
+				AND = {
 					owns = 634
 					owns = 636
 					owns = 638
@@ -329,50 +382,53 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
-	}
-		
+			war = no
+			state_n_government = 1
+		}
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 633 }
-			633 = { 
 				change_province_name = "Bratislava" #Called Prešporok by the Slovaks before 1918
-				state_scope = { change_region_name = "Slovensko" }
-			}
-				owner = { set_global_flag = slovakia_rename_czhslopres_1918 }
-				owner = { clr_global_flag = slovakia_rename_hunpres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres }
+				owner = {
+					set_global_flag = slovakia_rename_czhslopres_1918
+					clr_global_flag = slovakia_rename_hunpres }
+					clr_global_flag = slovakia_rename_czhslopres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 634 }
-			634 = { change_province_name = "Trencín" }
-			636 = { change_province_name = "Banská Bystrica" }
-			638 = { change_province_name = "Prešov" }
-			3310 = { change_province_name = "Vyšná Jablonka" }
-				owner = { set_global_flag = slovakia_rename_czhslo_1918 }
-				owner = { clr_global_flag = slovakia_rename_hun }
-				owner = { clr_global_flag = slovakia_rename_czhslo }
+				change_province_name = "Trencín"
+				state_scope = { change_region_name = "Slovensko" }
+				636 = { change_province_name = "Banská Bystrica" }
+				638 = { change_province_name = "Prešov" }
+				3310 = { change_province_name = "Vyšná Jablonka" }
+				owner = {
+					set_global_flag = slovakia_rename_czhslo_1918
+					clr_global_flag = slovakia_rename_hun
+					clr_global_flag = slovakia_rename_czhslo
+				}
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	slovakia_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 			}
 			OR = {
-				AND = { 
-					owns = 633 
+				AND = {
+					owns = 633
 					NOT = { has_global_flag = slovakia_rename_hunpres }
 				}
-				AND = { 
+				AND = {
 					owns = 634
 					owns = 636
 					owns = 638
@@ -380,53 +436,57 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 633 }
-			633 = { 
 				change_province_name = "Pozsony"
-				state_scope = { change_region_name = "Pozsony" }
-			}
-				owner = { set_global_flag = slovakia_rename_hunpres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres_1918 }
+				owner = {
+					set_global_flag = slovakia_rename_hunpres
+					clr_global_flag = slovakia_rename_czhslopres
+					clr_global_flag = slovakia_rename_czhslopres_1918
+				}
 			}
 			random_owned = {
 				limit = { province_id = 634 }
-			634 = { change_province_name = "Trencsén" }
-			636 = { change_province_name = "Besztercebánya" }
-			638 = { change_province_name = "Eperjes" }
-			3310 = { change_province_name = "Felsöalmád" }
-				owner = { set_global_flag = slovakia_rename_hun }
-				owner = { clr_global_flag = slovakia_rename_czhslo }
-				owner = { clr_global_flag = slovakia_rename_czhslo_1918 }
+				change_province_name = "Trencsén"
+				state_scope = { change_region_name = "Pozsony" }
+				636 = { change_province_name = "Besztercebánya" }
+				638 = { change_province_name = "Eperjes" }
+				3310 = { change_province_name = "Felsöalmád" }
+				owner = {
+					set_global_flag = slovakia_rename_hun
+					clr_global_flag = slovakia_rename_czhslo
+					clr_global_flag = slovakia_rename_czhslo_1918
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	slovakia_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
-				tag = KUK 
+				tag = KUK
 				tag = DNB
 			}
 			OR = {
-				AND = { 
-					owns = 633 
+				AND = {
+					owns = 633
 					OR = {
 						has_global_flag = slovakia_rename_czhslopres
 						has_global_flag = slovakia_rename_hunpres
 					}
 				}
-				AND = { 
+				AND = {
 					owns = 634
 					owns = 636
 					owns = 638
@@ -437,37 +497,42 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 633 }
-			633 = { 
 				change_province_name = "Preßburg"
-				state_scope = { change_region_name = "Oberungarn" }
-			}
-				owner = { clr_global_flag = slovakia_rename_hunpres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres }
-				owner = { clr_global_flag = slovakia_rename_czhslopres_1918 }
+				owner = {
+					clr_global_flag = slovakia_rename_hunpres
+					clr_global_flag = slovakia_rename_czhslopres
+					clr_global_flag = slovakia_rename_czhslopres_1918
+				}
 			}
 			random_owned = {
 				limit = { province_id = 634 }
-			634 = { change_province_name = "Trentschin" }
-			636 = { change_province_name = "Neusohl" }
-			638 = { change_province_name = "Eperies" }
-			3310 = { change_province_name = "Jablonka" }
-				owner = { clr_global_flag = slovakia_rename_hun}
-				owner = { clr_global_flag = slovakia_rename_czhslo }
-				owner = { clr_global_flag = slovakia_rename_czhslo_1918 }
+				change_province_name = "Trentschin"
+				state_scope = { change_region_name = "Oberungarn" }
+				636 = { change_province_name = "Neusohl" }
+				638 = { change_province_name = "Eperies" }
+				3310 = { change_province_name = "Jablonka" }
+				owner = {
+					clr_global_flag = slovakia_rename_hun
+					clr_global_flag = slovakia_rename_czhslo
+					clr_global_flag = slovakia_rename_czhslo_1918
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Southern Slovakia ##
+
 	s_slovakia_rename_czhslo = {
 		picture = gtfo
 		potential = {
@@ -475,108 +540,114 @@ political_decisions = {
 				is_culture_group = czecho_slovak_culture_group
 				tag = SLV
 				tag = CZH
+				tag = WSF
 				AND = {
 					tag = DNB
 					accepted_culture = slovak
 				}
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 635
 					NOT = { has_global_flag = s_slovakia_rename_czhslopres }
 				}
-				AND = { 
+				AND = {
 					owns = 637
 					NOT = { has_global_flag = s_slovakia_rename_czhslo }
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 635 }
-			635 = { 
 				change_province_name = "Nitra"
 				state_scope = { change_region_name = "Južné Slovensko" }
-			}
 				owner = { set_global_flag = s_slovakia_rename_czhslopres }
 				owner = { clr_global_flag = s_slovakia_rename_hunpres }
 			}
 			random_owned = {
 				limit = { province_id = 637 }
-			637 = { change_province_name = "Košice" }
-				owner = { set_global_flag = s_slovakia_rename_czhslo }
-				owner = { clr_global_flag = s_slovakia_rename_hun }
+				change_province_name = "Košice"
+				owner = {
+					set_global_flag = s_slovakia_rename_czhslo
+					clr_global_flag = s_slovakia_rename_hun
+				}
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	s_slovakia_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 635
 					NOT = { has_global_flag = s_slovakia_rename_hunpres }
 				}
-				AND = { 
+				AND = {
 					owns = 637
 					NOT = { has_global_flag = s_slovakia_rename_hun }
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 635 }
-			635 = { 
 				change_province_name = "Nyitra"
 				state_scope = { change_region_name = "Észak-Magyarország" }
-			}
-				owner = { set_global_flag = s_slovakia_rename_hunpres }
-				owner = { clr_global_flag = s_slovakia_rename_czhslopres }
+				owner = {
+					set_global_flag = s_slovakia_rename_hunpres
+					clr_global_flag = s_slovakia_rename_czhslopres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 637 }
-			637 = { change_province_name = "Kassa" }
-				owner = { set_global_flag = s_slovakia_rename_hun }
-				owner = { clr_global_flag = s_slovakia_rename_czhslo }
+				change_province_name = "Kassa"
+				owner = {
+					set_global_flag = s_slovakia_rename_hun
+					clr_global_flag = s_slovakia_rename_czhslo
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	s_slovakia_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
-				tag = KUK 
+				tag = KUK
 				tag = DNB
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 635
 					OR = {
 						has_global_flag = s_slovakia_rename_czhslopres
 						has_global_flag = s_slovakia_rename_hunpres
 					}
 				}
-				AND = { 
+				AND = {
 					owns = 637
 					OR = {
 						has_global_flag = s_slovakia_rename_czhslo
@@ -585,32 +656,37 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 635 }
-			635 = { 
 				change_province_name = "Neutra"
 				state_scope = { change_region_name = "Nordungarn" }
-			}
-				owner = { clr_global_flag = s_slovakia_rename_hunpres }
-				owner = { clr_global_flag = s_slovakia_rename_czhslopres }
+				owner = {
+					clr_global_flag = s_slovakia_rename_hunpres
+					clr_global_flag = s_slovakia_rename_czhslopres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 637 }
-			637 = { change_province_name = "Kaschau" }
-				owner = { clr_global_flag = s_slovakia_rename_hun}
-				owner = { clr_global_flag = s_slovakia_rename_czhslo }
+				change_province_name = "Kaschau"
+				owner = {
+					clr_global_flag = s_slovakia_rename_hun
+					clr_global_flag = s_slovakia_rename_czhslo
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Carpatho - Ukraine ##
+
 	car_ukr_rename_czhslo = {
 		picture = gtfo
 		potential = {
@@ -618,146 +694,157 @@ political_decisions = {
 				is_culture_group = czecho_slovak_culture_group
 				tag = SLV
 				tag = CZH
+				tag = WSF
 				AND = {
 					tag = DNB
 					accepted_culture = slovak
 				}
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 950
 					NOT = { has_global_flag = car_ukr_rename_czhslopres }
 				}
-				AND = { 
+				AND = {
 					owns = 3308
 					NOT = { has_global_flag = car_ukr_rename_czhslo }
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 950 }
-			950 = { 
 				change_province_name = "Hust"
 				state_scope = { change_region_name = "Podkarpatská Rus" }
-			}
-				owner = { set_global_flag = car_ukr_rename_czhslopres }
-				owner = { clr_global_flag = car_ukr_rename_hunpres }
-				owner = { clr_global_flag = car_ukr_rename_ukrpres }
+				owner = {
+					set_global_flag = car_ukr_rename_czhslopres
+					clr_global_flag = car_ukr_rename_hunpres
+					clr_global_flag = car_ukr_rename_ukrpres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 3308 }
-			3308 = { change_province_name = "Užhorod" }
-				owner = { set_global_flag = car_ukr_rename_czhslo }
-				owner = { clr_global_flag = car_ukr_rename_ukr }
+				change_province_name = "Užhorod"
+				owner = {
+					set_global_flag = car_ukr_rename_czhslo
+					clr_global_flag = car_ukr_rename_ukr
+				}
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	car_ukr_rename_ukr = {
 		picture = gtfo
 		potential = {
 			is_culture_group = east_slavic
 			OR = {
-				AND = { 
+				AND = {
 					owns = 950
 					NOT = { has_global_flag = car_ukr_rename_ukrpres }
 				}
-				AND = { 
+				AND = {
 					owns = 3308
 					NOT = { has_global_flag = car_ukr_rename_ukr }
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 950 }
-			950 = { 
 				change_province_name = "Khust"
 				state_scope = { change_region_name = "Sakarpatia" }
-			}
-				owner = { set_global_flag = car_ukr_rename_ukrpres }
-				owner = { clr_global_flag = car_ukr_rename_hunpres }
-				owner = { clr_global_flag = car_ukr_rename_czhslopres }
+				owner = {
+					set_global_flag = car_ukr_rename_ukrpres
+					clr_global_flag = car_ukr_rename_hunpres
+					clr_global_flag = car_ukr_rename_czhslopres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 3308 }
-			3308 = { change_province_name = "Uzhhorod" }
-				owner = { set_global_flag = car_ukr_rename_ukr }
-				owner = { clr_global_flag = car_ukr_rename_czhslo }
-				owner = { clr_global_flag = car_ukr_rename_hun }
+				change_province_name = "Uzhhorod"
+				owner = {
+					set_global_flag = car_ukr_rename_ukr
+					clr_global_flag = car_ukr_rename_czhslo
+					clr_global_flag = car_ukr_rename_hun
+				}
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	car_ukr_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 950
 					NOT = { has_global_flag = car_ukr_rename_hunpres }
 				}
-				AND = { 
+				AND = {
 					owns = 3308
 					NOT = { has_global_flag = car_ukr_rename_hun }
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 950 }
-			950 = { 
 				change_province_name = "Huszt"
 				state_scope = { change_region_name = "Kárpátalja" }
-			}
-				owner = { set_global_flag = car_ukr_rename_hunpres }
-				owner = { clr_global_flag = car_ukr_rename_czhslopres }
-				owner = { clr_global_flag = car_ukr_rename_ukrpres }
+				owner = {
+					set_global_flag = car_ukr_rename_hunpres
+					clr_global_flag = car_ukr_rename_czhslopres
+					clr_global_flag = car_ukr_rename_ukrpres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 3308 }
-			3308 = { change_province_name = "Ungvár" }
-				owner = { set_global_flag = car_ukr_rename_hun }
-				owner = { clr_global_flag = car_ukr_rename_czhslo }
+				change_province_name = "Ungvár"
+				owner = {
+					set_global_flag = car_ukr_rename_hun
+					clr_global_flag = car_ukr_rename_czhslo
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	car_ukr_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
-				tag = KUK 
+				tag = KUK
 				tag = DNB
 			}
 			OR = {
-				AND = { 
+				AND = {
 					owns = 950
 					OR = {
 						has_global_flag = car_ukr_rename_czhslopres
@@ -765,7 +852,7 @@ political_decisions = {
 						has_global_flag = car_ukr_rename_ukrpres
 					}
 				}
-				AND = { 
+				AND = {
 					owns = 3308
 					OR = {
 						has_global_flag = car_ukr_rename_czhslo
@@ -775,34 +862,39 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 950 }
-			950 = { 
 				change_province_name = "Chust"
 				state_scope = { change_region_name = "Karpatenukraine" }
-			}
-				owner = { clr_global_flag = car_ukr_rename_hunpres }
-				owner = { clr_global_flag = car_ukr_rename_czhslopres }
-				owner = { clr_global_flag = car_ukr_rename_ukrpres }
+				owner = {
+					clr_global_flag = car_ukr_rename_hunpres
+					clr_global_flag = car_ukr_rename_czhslopres
+					clr_global_flag = car_ukr_rename_ukrpres
+				}
 			}
 			random_owned = {
 				limit = { province_id = 634 }
-			3308 = { change_province_name = "Ungwar" }
-				owner = { clr_global_flag = car_ukr_rename_hun}
-				owner = { clr_global_flag = car_ukr_rename_czhslo }
-				owner = { clr_global_flag = car_ukr_rename_ukr }
+				change_province_name = "Ungwar"
+				owner = {
+					clr_global_flag = car_ukr_rename_hun
+					clr_global_flag = car_ukr_rename_czhslo
+					clr_global_flag = car_ukr_rename_ukr
+				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Central Hungary ##
+
 	central_hungary_rename_hun = {
 		picture = gtfo
 		potential = {
@@ -813,23 +905,25 @@ political_decisions = {
 			owns = 641
 			NOT = { has_global_flag = central_hungary_rename_hun }
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = central_hungary_rename_hun
+			clr_global_flag = central_hungary_rename_tur
 			random_owned = {
 				limit = { owner = { NOT = { has_global_flag = budapest_founded } } }
-				641 = { 
+				641 = {
 					change_province_name = "Pest"
 					state_scope = { change_region_name = "Közép-Magyarország" }
 				}
 			}
 			random_owned = {
 				limit = { owner = { has_global_flag = budapest_founded } }
-				641 = { 
+				641 = {
 					change_province_name = "Budapest"
 					state_scope = { change_region_name = "Közép-Magyarország" }
 				}
@@ -842,32 +936,37 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	central_hungary_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = { accepted_culture = hungarian }
 			owns = 641
-			has_global_flag = central_hungary_rename_hun
+			OR = {
+				has_global_flag = central_hungary_rename_tur
+				has_global_flag = central_hungary_rename_hun
+			}
 		}
-		
+
 		allow = {
-			war = no			state_n_government = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = central_hungary_rename_hun
+			clr_global_flag = central_hungary_rename_tur
 			random_owned = {
 				limit = { owner = { NOT = { has_global_flag = budapest_founded } } }
-				641 = { 
+				641 = {
 					change_province_name = "Pest"
 					state_scope = { change_region_name = "Pest-Ofen" }
 				}
 			}
 			random_owned = {
 				limit = { owner = { has_global_flag = budapest_founded } }
-				641 = { 
+				641 = {
 					change_province_name = "Ofen-Pest"
 					state_scope = { change_region_name = "Pest-Ofen" }
 				}
@@ -878,10 +977,52 @@ political_decisions = {
 			649 = { change_province_name = "Szegedin" }
 			650 = { change_province_name = "Tschabe" }
 		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	central_hungary_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 641
+			NOT = { has_global_flag = central_hungary_rename_tur }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = central_hungary_rename_tur
+			clr_global_flag = central_hungary_rename_hun
+			random_owned = {
+				limit = { owner = { NOT = { has_global_flag = budapest_founded } } }
+				641 = {
+					change_province_name = "Peste"
+					state_scope = { change_region_name = "Büyük Macaristan Ovasi" }
+				}
+			}
+			random_owned = {
+				limit = { owner = { has_global_flag = budapest_founded } }
+				641 = {
+					change_province_name = "Budapeste"
+					state_scope = { change_region_name = "Büyük Macaristan Ovasi" }
+				}
+			}
+			645 = { change_province_name = "Kecskemét" }
+			646 = { change_province_name = "Miskofça" }
+			648 = { change_province_name = "Debreçin" }
+			649 = { change_province_name = "Segedin" }
+			650 = { change_province_name = "Bekescsaba" }
+		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Banat ##
+
 	banat_rename_ser = {
 		picture = greater_serbia
 		potential = {
@@ -891,28 +1032,34 @@ political_decisions = {
 				tag = YUG
 			}
 			owns = 652
-			owns = 653
 			NOT = { has_global_flag = banat_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = banat_rename_ser
 			clr_global_flag = banat_rename_hun
 			clr_global_flag = banat_rename_rom
-			prestige = 2
-			652 = { change_province_name = "Temišvar" 
+			clr_global_flag = banat_rename_tur
+			652 = {
+				change_province_name = "Temišvar"
 				state_scope = { change_region_name = "Banat" }
 			}
-			653 = { change_province_name = "Rešica" }
+			any_owned = {
+				limit = {
+					province_id = 653
+				}
+				change_province_name = "Rešica"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	banat_rename_hun = {
 		picture = gtfo
 		potential = {
@@ -921,52 +1068,60 @@ political_decisions = {
 			owns = 653
 			NOT = { has_global_flag = banat_rename_hun }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = banat_rename_hun
 			clr_global_flag = banat_rename_ser
 			clr_global_flag = banat_rename_rom
-			prestige = 2
-			652 = { change_province_name = "Temesvar" 
+			clr_global_flag = banat_rename_tur
+			652 = {
+				change_province_name = "Temesvar"
 				state_scope = { change_region_name = "Bánság" }
 			}
 			653 = { change_province_name = "Resicabánya" }
 		}
-			ai_will_do = { factor = 1 }
+
+		ai_will_do = { factor = 1 }
 	}
-	
+
 	banat_rename_rom = {
 		picture = gtfo
 		potential = {
 			primary_culture = romanian
-			owns = 652
 			owns = 653
 			NOT = { has_global_flag = banat_rename_rom }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = banat_rename_rom
 			clr_global_flag = banat_rename_ser
 			clr_global_flag = banat_rename_hun
-			prestige = 2
-			652 = { change_province_name = "Timi?oara" 
+			clr_global_flag = banat_rename_tur
+			any_owned = {
+				limit = {
+					province_id = 652
+				}
+				change_province_name = "Timisoara"
+			}
+			653 = {
+				change_province_name = "Resita"
 				state_scope = { change_region_name = "Banat" }
 			}
-			653 = { change_province_name = "Re?i?a" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	banat_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -975,33 +1130,67 @@ political_decisions = {
 				has_global_flag = banat_rename_ser
 				has_global_flag = banat_rename_hun
 				has_global_flag = banat_rename_rom
+				has_global_flag = banat_rename_rom
 			}
 			owns = 652
 			owns = 653
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = banat_rename_ser
 			clr_global_flag = banat_rename_hun
 			clr_global_flag = banat_rename_rom
-			652 = { change_province_name = "Temeschburg" 
+			clr_global_flag = banat_rename_tur
+			652 = {
+				change_province_name = "Temeschburg"
 				state_scope = { change_region_name = "Banat" }
 			}
 			653 = { change_province_name = "Reschitz" }
 		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	banat_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			NOT = {	has_global_flag = banat_rename_tur }
+			owns = 652
+			owns = 653
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = banat_rename_tur
+			clr_global_flag = banat_rename_ser
+			clr_global_flag = banat_rename_hun
+			clr_global_flag = banat_rename_rom
+			652 = {
+				change_province_name = "Temesvar"
+				state_scope = { change_region_name = "Temesvar Eyaleti" }
+			}
+			653 = { change_province_name = "Resçe" }
+		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Northern Transylvania -- Beware of Vampires ##
+
 	northern_transylvania_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 				tag = DNB
@@ -1013,17 +1202,17 @@ political_decisions = {
 			owns = 660
 			NOT = { has_global_flag = northern_transylvania_rename_hun }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = northern_transylvania_rename_hun
 			clr_global_flag = northern_transylvania_rename_rom
-			prestige = 2
-			651 = { 
+			clr_global_flag = northern_transylvania_rename_tur
+			651 = {
 				change_province_name = "Szatmár"
 				state_scope = { change_region_name = "Észak-Erdély" }
 			}
@@ -1032,9 +1221,10 @@ political_decisions = {
 			661 = { change_province_name = "Beszterce" }
 			660 = { change_province_name = "Udvarhely" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	northern_transylvania_rename_rom = {
 		picture = gtfo
 		potential = {
@@ -1046,34 +1236,35 @@ political_decisions = {
 			owns = 660
 			NOT = { has_global_flag = northern_transylvania_rename_rom }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = northern_transylvania_rename_rom
 			clr_global_flag = northern_transylvania_rename_hun
-			prestige = 2
-			654 = { 
+			clr_global_flag = northern_transylvania_rename_tur
+			654 = {
 				change_province_name = "Cluj"
 				state_scope = { change_region_name = "Transilvania de Nord" }
 			}
 			651 = { change_province_name = "Careii Mari" }
-			
+
 			661 = { change_province_name = "Bistrita" }
 			660 = { change_province_name = "Trei Scaune" }
 			2533 = { change_province_name = "Tîrgu Mures" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	northern_transylvania_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { 
+			NOT = {
 				OR = {
 					tag = KUK
 					tag = DNB
@@ -1087,19 +1278,21 @@ political_decisions = {
 			OR = {
 				has_global_flag = northern_transylvania_rename_hun
 				has_global_flag = northern_transylvania_rename_rom
+				has_global_flag = northern_transylvania_rename_tur
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = northern_transylvania_rename_hun
 			clr_global_flag = northern_transylvania_rename_rom
-			651 = { 
-				change_province_name = "Sathmar" 
+			clr_global_flag = northern_transylvania_rename_tur
+			651 = {
+				change_province_name = "Sathmar"
 				state_scope = { change_region_name = "Nord-Siebenbürgen" }
 			}
 			654 = { change_province_name = "Klausenburg" }
@@ -1107,14 +1300,51 @@ political_decisions = {
 			660 = { change_province_name = "Oderhellen" }
 			2533 = { change_province_name = "Neumarkt" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
-## Southern Transylvania -- Beware of Werewolves ##	
+	northern_transylvania_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 651
+			owns = 654
+			owns = 661
+			owns = 2533
+			owns = 660
+			NOT = { has_global_flag = northern_transylvania_rename_tur }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = northern_transylvania_rename_tur
+			clr_global_flag = northern_transylvania_rename_rom
+			clr_global_flag = northern_transylvania_rename_hun
+			654 = {
+				change_province_name = "Kalosvar"
+				state_scope = { change_region_name = "Kuzey Erdel" }
+			}
+			651 = { change_province_name = "Karolvar" }
+
+			661 = { change_province_name = "Bistrita" }
+			660 = { change_province_name = "Sekelistan" }
+			2533 = { change_province_name = "Osorhei" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Southern Transylvania -- Beware of Werewolves ##
+
 	southern_transylvania_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 				tag = DNB
@@ -1126,18 +1356,18 @@ political_decisions = {
 			owns = 659
 			NOT = { has_global_flag = southern_transylvania_rename_hun }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = southern_transylvania_rename_hun
 			clr_global_flag = southern_transylvania_rename_rom
-			prestige = 2
-			647 = { 
-				change_province_name = "Nagyvárad" 
+			clr_global_flag = southern_transylvania_rename_tur
+			647 = {
+				change_province_name = "Nagyvárad"
 				state_scope = { change_region_name = "Dél-Erdély" }
 			}
 			657 = { change_province_name = "Nagyszeben" }
@@ -1145,9 +1375,10 @@ political_decisions = {
 			656 = { change_province_name = "Déva" }
 			659 = { change_province_name = "Brassó" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	southern_transylvania_rename_rom = {
 		picture = gtfo
 		potential = {
@@ -1159,33 +1390,34 @@ political_decisions = {
 			owns = 659
 			NOT = { has_global_flag = southern_transylvania_rename_rom }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = southern_transylvania_rename_rom
 			clr_global_flag = southern_transylvania_rename_hun
-			prestige = 2
+			clr_global_flag = southern_transylvania_rename_tur
 			647 = {  change_province_name = "Oradea" }
-			657 = { 
+			657 = {
 				change_province_name = "Sibiu"
 				state_scope = { change_region_name = "Transilvania de Sud" }
 			}
 			655 = { change_province_name = "Alba Iulia" }
 			656 = { change_province_name = "Deva" }
-			659 = { change_province_name = "Bra?ov" }
+			659 = { change_province_name = "Brasov" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	southern_transylvania_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { 
+			NOT = {
 				OR = {
 					tag = KUK
 					tag = DNB
@@ -1199,17 +1431,19 @@ political_decisions = {
 			OR = {
 				has_global_flag = southern_transylvania_rename_hun
 				has_global_flag = southern_transylvania_rename_rom
+				has_global_flag = southern_transylvania_rename_tur
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = southern_transylvania_rename_hun
 			clr_global_flag = southern_transylvania_rename_rom
+			clr_global_flag = southern_transylvania_rename_tur
 			647 = { change_province_name = "Großwardein" }
 			655 = { change_province_name = "Weißenburg" }
 			656 = { change_province_name = "Diemrich" }
@@ -1219,10 +1453,46 @@ political_decisions = {
 			}
 			659 = { change_province_name = "Kronstadt" }
 		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	southern_transylvania_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 647
+			owns = 655
+			owns = 656
+			owns = 657
+			owns = 659
+			NOT = { has_global_flag = southern_transylvania_rename_tur }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = southern_transylvania_rename_tur
+			clr_global_flag = southern_transylvania_rename_hun
+			clr_global_flag = southern_transylvania_rename_rom
+			647 = {  change_province_name = "Oradea" }
+			657 = {
+				change_province_name = "Sibin"
+				state_scope = { change_region_name = "Güney Erdel" }
+			}
+			655 = { change_province_name = "Belgrad-i Erdel" }
+			656 = { change_province_name = "Devevar" }
+			659 = { change_province_name = "Barasu" }
+		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## West Galicia ##
+
 	galicia_rename_german = {
 		picture = gtfo
 		potential = {
@@ -1236,23 +1506,22 @@ political_decisions = {
 			OR = {
 				AND = { owns = 703 NOT = { has_global_flag = german_renamed_krakow } }
 				AND = { owns = 714 NOT = { has_global_flag = german_renamed_galicia } }
-				
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 703
 				}
 				703 = { change_province_name = "Krakau"  }
-				owner = { 
-					set_global_flag = german_renamed_krakow 
+				owner = {
+					set_global_flag = german_renamed_krakow
 					clr_global_flag = polish_renamed_krakow
 					clr_global_flag = russian_renamed_krakow
 				}
@@ -1261,24 +1530,25 @@ political_decisions = {
 				limit = {
 					province_id = 714
 				}
-				714 = { 
-					change_province_name = "Tarnau" 
+				714 = {
+					change_province_name = "Tarnau"
 					state_scope = { change_region_name = "Westgalizien" }
 				}
 				704 = { change_province_name = "Neu Sandez"  }
 				705 = { change_province_name = "Premissel"  }
 				3285 = { change_province_name = "Frauenstadt"  }
 				3331 = { change_province_name = "Jaroslau"  }
-				owner = { 
-					set_global_flag = german_renamed_galicia 
-					clr_global_flag = polish_renamed_galicia 
-					clr_global_flag = russian_renamed_galicia 
+				owner = {
+					set_global_flag = german_renamed_galicia
+					clr_global_flag = polish_renamed_galicia
+					clr_global_flag = russian_renamed_galicia
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	polish_renamed_galicia = {
 		picture = gtfo
 		potential = {
@@ -1295,19 +1565,19 @@ political_decisions = {
 				AND = { owns = 714 NOT = { has_global_flag = polish_renamed_galicia } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 703
 				}
 				703 = { change_province_name = "Kraków"  }
-				owner = { 
+				owner = {
 					set_global_flag = polish_renamed_krakow
 					clr_global_flag = german_renamed_krakow
 					clr_global_flag = russian_renamed_krakow
@@ -1317,24 +1587,25 @@ political_decisions = {
 				limit = {
 					province_id = 714
 				}
-				714 = { 
-					change_province_name = "Tarnów" 
+				714 = {
+					change_province_name = "Tarnów"
 					state_scope = { change_region_name = "Galicja Zachodnia" }
 				}
 				704 = { change_province_name = "Nowy Sacz"  }
 				705 = { change_province_name = "Przemysl"  }
 				3285 = { change_province_name = "Wadowice"  }
 				3331 = { change_province_name = "Jaroslaw"  }
-				owner = { 
-					set_global_flag = polish_renamed_galicia 
-					clr_global_flag = german_renamed_galicia 
-					clr_global_flag = russian_renamed_galicia 
+				owner = {
+					set_global_flag = polish_renamed_galicia
+					clr_global_flag = german_renamed_galicia
+					clr_global_flag = russian_renamed_galicia
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	russian_renamed_galicia = {
 		picture = gtfo
 		potential = {
@@ -1347,19 +1618,19 @@ political_decisions = {
 				AND = { owns = 714 NOT = { has_global_flag = russian_renamed_galicia } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 703
 				}
 				703 = { change_province_name = "Krakov" }
-				owner = { 
+				owner = {
 					set_global_flag = russian_renamed_krakow
 					clr_global_flag = german_renamed_krakow
 					clr_global_flag = polish_renamed_krakow
@@ -1369,8 +1640,8 @@ political_decisions = {
 				limit = {
 					province_id = 714
 				}
-				714 = { 
-					change_province_name = "Tarniv" 
+				714 = {
+					change_province_name = "Tarniv"
 					state_scope = { change_region_name = "Krakov" }
 				}
 				703 = { change_province_name = "Krakov" }
@@ -1378,17 +1649,19 @@ political_decisions = {
 				705 = { change_province_name = "Peremyshl"  }
 				3285 = { change_province_name = "Vadovitse"  }
 				3331 = { change_province_name = "Yaroslav"  }
-				owner = { 
+				owner = {
 					set_global_flag = russian_renamed_galicia
-					clr_global_flag = german_renamed_galicia 
+					clr_global_flag = german_renamed_galicia
 					clr_global_flag = polish_renamed_galicia
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## East Galicia ##
+
 	east_galicia_rename_rus = {
 		picture = gtfo
 		potential = {
@@ -1402,32 +1675,33 @@ political_decisions = {
 			owns = 953
 			NOT = { has_global_flag = east_galicia_rename_rus }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = east_galicia_rename_rus
 			clr_global_flag = east_galicia_rename_polish
-			702 = { 
-				change_province_name = "L’viv" 
+			702 = {
+				change_province_name = "L’viv"
 				state_scope = { change_region_name = "L’viv" }
 			}
 			951 = { change_province_name = "Stryy" }
 			952 = { change_province_name = "Ternopol" }
 			953 = { change_province_name = "Stanislav" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	east_galicia_rename_polish = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = polish
-				AND = { 
+				AND = {
 					tag = DNB
 					accepted_culture = polish
 				}
@@ -1439,26 +1713,27 @@ political_decisions = {
 			owns = 953
 			NOT = { has_global_flag = east_galicia_rename_polish }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = east_galicia_rename_polish
 			clr_global_flag = east_galicia_rename_rus
-			702 = { 
-				change_province_name = "Lwów" 
+			702 = {
+				change_province_name = "Lwów"
 				state_scope = { change_region_name = "Galicja Wschodnia" }
 			}
 			951 = { change_province_name = "Stryj" }
 			952 = { change_province_name = "Tarnopol" }
 			953 = { change_province_name = "Stanislawów" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	east_galicia_rename_german = {
 		picture = gtfo
 		potential = {
@@ -1478,27 +1753,29 @@ political_decisions = {
 			owns = 952
 			owns = 953
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = east_galicia_rename_polish
 			clr_global_flag = east_galicia_rename_rus
-			702 = { 
-				change_province_name = "Lemberg" 
+			702 = {
+				change_province_name = "Lemberg"
 				state_scope = { change_region_name = "Ostgalizien" }
 			}
 			951 = { change_province_name = "Stryi" }
 			952 = { change_province_name = "Tarnopol" }
 			953 = { change_province_name = "Stanislau" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Bukovina ##
+
 	bukovina_rename_rom = {
 		picture = gtfo
 		potential = {
@@ -1509,20 +1786,23 @@ political_decisions = {
 		}
 
 		allow = {
-			war = no			state_n_government = 1
-
+			war = no
+			state_n_government = 1
 		}
 
 		effect = {
 			set_global_flag = bukovina_rename_rom
 			clr_global_flag = bukovina_rename_aus
 			clr_global_flag = bukovina_rename_rus
-			662 = { change_province_name = "Cernauti"  
-					state_scope = {
-					change_region_name = "Bucovina"}
-							}
+			662 = {
+				change_province_name = "Cernauti"
+				state_scope = {
+					change_region_name = "Bucovina"
+				}
+			}
 			663 = { change_province_name = "Suceava" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1536,54 +1816,62 @@ political_decisions = {
 		}
 
 		allow = {
-			war = no			state_n_government = 1
-
+			war = no
+			state_n_government = 1
 		}
 
 		effect = {
 			set_global_flag = bukovina_rename_aus
 			clr_global_flag = bukovina_rename_rom
 			clr_global_flag = bukovina_rename_rus
-			662 = { change_province_name = "Czernowitz"  
-					state_scope = {
-					change_region_name = "Buchenland"}
-							}
+			662 = {
+				change_province_name = "Czernowitz"
+				state_scope = {
+					change_region_name = "Buchenland"
+				}
+			}
 			663 = { change_province_name = "Sotschen" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	bukovina_rename_rus = {
 		picture = gtfo
 		potential = {
-			OR = {
-				primary_culture = russian
-				primary_culture = ukrainian
-			}
+			is_culture_group = east_slavic
 			owns = 662
-			owns = 663
 			NOT = { has_global_flag = bukovina_rename_rus }
 		}
 
 		allow = {
-			war = no			state_n_government = 1
-
+			war = no
+			state_n_government = 1
 		}
 
 		effect = {
 			set_global_flag = bukovina_rename_rus
 			clr_global_flag = bukovina_rename_rom
 			clr_global_flag = bukovina_rename_aus
-			662 = { change_province_name = "Chernovitsy" 
-					state_scope = {
-					change_region_name = "Bukovyna"}
-							}
-			663 = { change_province_name = "Sucava" }
+			662 = {
+				change_province_name = "Chernovitsy"
+				state_scope = {
+					change_region_name = "Bukovyna"
+				}
+			}
+			any_owned = {
+				limit = {
+					province_id = 663
+				}
+				change_province_name = "Sucava"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Lombardy ##
+
 	german_lombardy = {
 		picture = gtfo
 		potential = {
@@ -1591,16 +1879,14 @@ political_decisions = {
 			owns = 726
 			owns = 727
 			owns = 728
-			NOT = {
-				has_global_flag = german_lombardy
-			}
+			NOT = {	has_global_flag = german_lombardy }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			726 = {
 				change_province_name = "Mailand"
@@ -1614,12 +1900,14 @@ political_decisions = {
 			728 = {
 				change_province_name = "Wälsch-Brixen"
 			}
-			2669 = { 
+			2669 = {
 				change_province_name = "Sünders"
 			}
 			set_global_flag = german_lombardy
 			clr_global_flag = italian_lombardy
 		}
+
+		ai_will_do = { factor = 1 }
 	}
 
 	italian_lombardy = {
@@ -1632,16 +1920,14 @@ political_decisions = {
 			owns = 726
 			owns = 727
 			owns = 728
-			NOT = {
-				has_global_flag = italian_lombardy
-			}
+			NOT = {	has_global_flag = italian_lombardy }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			726 = {
 				change_province_name = "Milano"
@@ -1655,15 +1941,18 @@ political_decisions = {
 			728 = {
 				change_province_name = "Brescia"
 			}
-			2669 = { 
+			2669 = {
 				change_province_name = "Sondrio"
 			}
 			set_global_flag = italian_lombardy
 			clr_global_flag = german_lombardy
 		}
+
+		ai_will_do = { factor = 1 }
 	}
 
-## Venetia ##	
+## Venetia ##
+
 	german_veneto = {
 		picture = gtfo
 		potential = {
@@ -1673,16 +1962,14 @@ political_decisions = {
 			owns = 731
 			owns = 732
 			owns = 733
-			NOT = {
-				has_global_flag = german_veneto
-			}
+			NOT = {	has_global_flag = german_veneto	}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			729 = {
 				change_province_name = "Venedig"
@@ -1696,6 +1983,8 @@ political_decisions = {
 			set_global_flag = german_veneto
 			clr_global_flag = italian_veneto
 		}
+
+		ai_will_do = { factor = 1 }
 	}
 
 	italian_veneto = {
@@ -1710,16 +1999,14 @@ political_decisions = {
 			owns = 731
 			owns = 732
 			owns = 733
-			NOT = {
-				has_global_flag = italian_veneto
-			}
+			NOT = {	has_global_flag = italian_veneto }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			729 = {
 				change_province_name = "Venezia"
@@ -1734,9 +2021,12 @@ political_decisions = {
 			set_global_flag = italian_veneto
 			clr_global_flag = german_veneto
 		}
+
+		ai_will_do = { factor = 1 }
 	}
 
 ## Istria ##
+
 	istria_rename_slo = {
 		picture = gtfo
 		potential = {
@@ -1746,23 +2036,23 @@ political_decisions = {
 			owns = 3288
 			NOT = { has_global_flag = istria_rename_slo }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_slo
 			clr_global_flag = istria_rename_ita_slo
-			prestige = 2
-		769 = { change_province_name = "Postojna" }
-		737 = { change_province_name = "Gorica" }
-		3288 = { change_province_name = "Trbiž" }
+			769 = { change_province_name = "Postojna" }
+			737 = { change_province_name = "Gorica" }
+			3288 = { change_province_name = "Trbiž" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_serbian = {
 		picture = greater_serbia
 		potential = {
@@ -1773,23 +2063,23 @@ political_decisions = {
 			owns = 3288
 			NOT = { has_global_flag = istria_rename_slo }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_slo
 			clr_global_flag = istria_rename_ita_slo
-			prestige = 2
-		769 = { change_province_name = "Postojna" }
-		737 = { change_province_name = "Gorica" }
-		3288 = { change_province_name = "Trbiž" }
+			769 = { change_province_name = "Postojna" }
+			737 = { change_province_name = "Gorica" }
+			3288 = { change_province_name = "Trbiž" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-		
+
 	istria_rename_ita_slo = {
 		picture = italia_irredenta
 		potential = {
@@ -1802,23 +2092,23 @@ political_decisions = {
 			owns = 3288
 			NOT = { has_global_flag = istria_rename_ita_slo }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_ita_slo
 			clr_global_flag = istria_rename_slo
-			prestige = 2
-		769 = { change_province_name = "Postumia" }
-		737 = { change_province_name = "Gorizia" }
-		3288 = { change_province_name = "Tarvisio" }
+			769 = { change_province_name = "Postumia" }
+			737 = { change_province_name = "Gorizia" }
+			3288 = { change_province_name = "Tarvisio" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_cro = {
 		picture = gtfo
 		potential = {
@@ -1827,27 +2117,27 @@ political_decisions = {
 			owns = 736
 			NOT = { has_global_flag = istria_rename_cro }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_cro
 			clr_global_flag = istria_rename_ita_cro
 			clr_global_flag = istria_rename_ser
 			clr_global_flag = istria_rename_slovene
-			prestige = 2
-		736 = { 
-			change_province_name = "Trst" 
-			state_scope = { change_region_name = "Istra" }
+			736 = {
+				change_province_name = "Trst"
+				state_scope = { change_region_name = "Istra" }
+			}
+			770 = { change_province_name = "Pula" }
 		}
-		770 = { change_province_name = "Pula" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_ser = {
 		picture = greater_serbia
 		potential = {
@@ -1857,27 +2147,27 @@ political_decisions = {
 			owns = 736
 			NOT = { has_global_flag = istria_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_ser
 			clr_global_flag = istria_rename_ita_cro
 			clr_global_flag = istria_rename_cro
 			clr_global_flag = istria_rename_slovene
-			prestige = 2
-		736 = { 
-			change_province_name = "Trst" 
-			state_scope = { change_region_name = "Istra" }
+			736 = {
+				change_province_name = "Trst"
+				state_scope = { change_region_name = "Istra" }
+			}
+			770 = { change_province_name = "Pula" }
 		}
-		770 = { change_province_name = "Pula" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_slovene = {
 		picture = gtfo
 		potential = {
@@ -1886,27 +2176,27 @@ political_decisions = {
 			owns = 736
 			NOT = { has_global_flag = istria_rename_slovene }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_slovene
 			clr_global_flag = istria_rename_ita_cro
 			clr_global_flag = istria_rename_cro
 			clr_global_flag = istria_rename_ser
-			prestige = 2
-		736 = { 
-			change_province_name = "Trst" 
-			state_scope = { change_region_name = "Istra" }
+			736 = {
+				change_province_name = "Trst"
+				state_scope = { change_region_name = "Istra" }
+			}
+			770 = { change_province_name = "Pulj" }
 		}
-		770 = { change_province_name = "Pulj" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_ita_cro = {
 		picture = italia_irredenta
 		potential = {
@@ -1918,27 +2208,27 @@ political_decisions = {
 			owns = 736
 			NOT = { has_global_flag = istria_rename_ita_cro }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_ita_cro
 			clr_global_flag = istria_rename_cro
 			clr_global_flag = istria_rename_ser
 			clr_global_flag = istria_rename_slovene
-			prestige = 2
-		736 = { 
-			change_province_name = "Trieste" 
-			state_scope = { change_region_name = "Istria" }
+			736 = {
+				change_province_name = "Trieste"
+				state_scope = { change_region_name = "Istria" }
+			}
+			770 = { change_province_name = "Pola" }
 		}
-		770 = { change_province_name = "Pola" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	istria_rename_yug = {
 		picture = gtfo
 		potential = {
@@ -1950,12 +2240,12 @@ political_decisions = {
 			owns = 3288
 			NOT = { has_global_flag = istria_rename_yug }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = istria_rename_yug
 			clr_global_flag = istria_rename_ita_cro
@@ -1964,19 +2254,19 @@ political_decisions = {
 			clr_global_flag = istria_rename_slovene
 			clr_global_flag = istria_rename_slo
 			clr_global_flag = istria_rename_ita_slo
-			prestige = 10
-		769 = { change_province_name = "Postojna" }
-		737 = { change_province_name = "Gorica" }
-		3288 = { change_province_name = "Trbiž" }
-		736 = { 
-			change_province_name = "Trst" 
-			state_scope = { change_region_name = "Istra" }
+			769 = { change_province_name = "Postojna" }
+			737 = { change_province_name = "Gorica" }
+			3288 = { change_province_name = "Trbiž" }
+			736 = {
+				change_province_name = "Trst"
+				state_scope = { change_region_name = "Istra" }
+			}
+			770 = { change_province_name = "Pula" }
 		}
-		770 = { change_province_name = "Pula" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-			
+
 	istria_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -2002,12 +2292,12 @@ political_decisions = {
 				}
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = istria_rename_yug
 			clr_global_flag = istria_rename_ita_cro
@@ -2016,19 +2306,21 @@ political_decisions = {
 			clr_global_flag = istria_rename_slo
 			clr_global_flag = istria_rename_ser
 			clr_global_flag = istria_rename_slovene
-		769 = { change_province_name = "Adelsberg" }
-		736 = { 
-			change_province_name = "Triest" 
-			state_scope = { change_region_name = "Istrien" }
+			769 = { change_province_name = "Adelsberg" }
+			736 = {
+				change_province_name = "Triest"
+				state_scope = { change_region_name = "Istrien" }
+			}
+			737 = { change_province_name = "Görz" }
+			770 = { change_province_name = "Polei" }
+			3288 = { change_province_name = "Tarvis" }
 		}
-		737 = { change_province_name = "Görz" }
-		770 = { change_province_name = "Polei" }
-		3288 = { change_province_name = "Tarvis" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Slovenia ##
+
 	slovene_rename_slo = {
 		picture = gtfo
 		potential = {
@@ -2040,28 +2332,28 @@ political_decisions = {
 			owns = 768
 			NOT = { has_global_flag = slovene_renamed_slo }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = slovene_renamed_slo
-			prestige = 2
-                768 = { 
-                    change_province_name = "Ljubljana" 
-                    state_scope = {
-                        change_region_name = "Slovenija" 
-                    }
-                }        
-                767 = { change_province_name = "Maribor" }    
-                3282 = { change_province_name = "Murska Sobota"}
-                3312 = { change_province_name = "Ptuj" }
+			768 = {
+				change_province_name = "Ljubljana"
+				state_scope = {
+					change_region_name = "Slovenija"
+				}
+			}
+			767 = { change_province_name = "Maribor" }
+			3282 = { change_province_name = "Murska Sobota"}
+			3312 = { change_province_name = "Ptuj" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	serbian_rename_slo = {
 		picture = gtfo
 		potential = {
@@ -2071,28 +2363,28 @@ political_decisions = {
 			owns = 768
 			NOT = { has_global_flag = slovene_renamed_slo }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = slovene_renamed_slo
-			prestige = 2
-                768 = { 
-                    change_province_name = "Ljubljana" 
-                    state_scope = {
-                        change_region_name = "Slovenija" 
-                    }
-                }        
-                767 = { change_province_name = "Maribor" }    
-                3282 = { change_province_name = "Murska Sobota"}
-                3312 = { change_province_name = "Ptuj" }
+			768 = {
+				change_province_name = "Ljubljana"
+				state_scope = {
+					change_region_name = "Slovenija"
+				}
+			}
+			767 = { change_province_name = "Maribor" }
+			3282 = { change_province_name = "Murska Sobota"}
+			3312 = { change_province_name = "Ptuj" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	slovene_rename_aus = {
 		picture = gtfo
 		potential = {
@@ -2101,28 +2393,30 @@ political_decisions = {
 			owns = 768
 			has_global_flag = slovene_renamed_slo
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = slovene_renamed_slo
-               768 = { 
-                    change_province_name = "Laibach" 
-                    state_scope = {
-                        change_region_name = "Krain"
-                    }
-                }        
-                767 = { change_province_name = "Marburg" }    
-                3282 = { change_province_name = "Olsnitz" }
-                3312 = { change_province_name = "Pettau" }
+			768 = {
+				change_province_name = "Laibach"
+				state_scope = {
+					change_region_name = "Krain"
+				}
+			}
+			767 = { change_province_name = "Marburg" }
+			3282 = { change_province_name = "Olsnitz" }
+			3312 = { change_province_name = "Pettau" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Croatia - Slavonia ##
+
 	croatia_rename_cro = {
 		picture = gtfo
 		potential = {
@@ -2136,68 +2430,115 @@ political_decisions = {
 			owns = 779
 			NOT = { has_global_flag = croatia_rename_cro }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = croatia_rename_cro
 			clr_global_flag = croatia_rename_hun
-			clr_global_flag = serbia_rename_cro
-			771 = { 
-				change_province_name = "Zagreb" 
+			clr_global_flag = croatia_rename_ser
+			clr_global_flag = croatia_rename_tur
+			771 = {
+				change_province_name = "Zagreb"
 				state_scope = { change_region_name = "Hrvatska-Slavonija" }
 			}
 			772 = { change_province_name = "Sisak" }
 			775 = { change_province_name = "Varaždin" }
 			776 = { change_province_name = "Bjelovar" }
 			3289 = { change_province_name = "Cakovec" }
-			777 = { change_province_name = "Požega" }
+			777 = {
+				any_country = {
+					limit = {
+						owns = 777
+						owns = 797
+					}
+					change_province_name = "Slavonska Požega"
+				}
+				any_country = {
+					limit = {
+						owns = 777
+						NOT = { owns = 797 }
+					}
+					change_province_name = "Požega"
+				}
+			}
 			779 = { change_province_name = "Osijek" }
-			3283 = { change_province_name = "Baranja" }
+			any_owned = {
+				limit = {
+					province_id = 3283
+				}
+				change_province_name = "Baranja"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	serbian_rename_cro = {
 		picture = greater_serbia
 		potential = {
 			primary_culture = serb
 			NOT = { tag = YUG }
-			owns = 771
-			NOT = { has_global_flag = serbia_rename_cro }
+			owns = 772
+			owns = 777
+			owns = 779
+			owns = 3283
+			NOT = { has_global_flag = croatia_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
-			set_global_flag = serbia_rename_cro
+			set_global_flag = croatia_rename_ser
 			clr_global_flag = croatia_rename_hun
 			clr_global_flag = croatia_rename_cro
-			771 = { 
-				change_province_name = "Zagreb" 
+			clr_global_flag = croatia_rename_tur
+			771 = {
+				change_province_name = "Zagreb"
 				state_scope = { change_region_name = "Hrvatska-Slavonija" }
 			}
 			772 = { change_province_name = "Sisak" }
 			775 = { change_province_name = "Varaždin" }
 			776 = { change_province_name = "Bjelovar" }
 			3289 = { change_province_name = "Cakovec" }
-			777 = { change_province_name = "Požega" }
+			777 = {
+				any_owned = {
+					limit = {
+						province_id = 777
+						owner = { owns = 797 }
+					}
+					change_province_name = "Slavonska Požega"
+				}
+				any_owned = {
+					limit = {
+						province_id = 777
+						owner = { NOT = { owns = 797 } }
+					}
+					change_province_name = "Požega"
+				}
+			}
 			779 = { change_province_name = "Osijek" }
-			3283 = { change_province_name = "Baranja" }
+			any_owned = {
+				limit = {
+					province_id = 3283
+				}
+				change_province_name = "Baranja"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	croatia_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 				tag = DNB
@@ -2208,18 +2549,19 @@ political_decisions = {
 			owns = 779
 			NOT = { has_global_flag = croatia_rename_hun }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = croatia_rename_hun
 			clr_global_flag = croatia_rename_cro
-			clr_global_flag = serbia_rename_cro
-			771 = { 
-				change_province_name = "Zabrag" 
+			clr_global_flag = croatia_rename_ser
+			clr_global_flag = croatia_rename_tur
+			771 = {
+				change_province_name = "Zabrag"
 				state_scope = { change_region_name = "Horvát-Királyság" }
 			}
 			772 = { change_province_name = "Sziszek" }
@@ -2229,43 +2571,52 @@ political_decisions = {
 			3289 = { change_province_name = "Csáktornya" }
 			777 = { change_province_name = "Pozsega" }
 			779 = { change_province_name = "Eszék" }
-			3283 = { change_province_name = "Baranya" }
+			any_owned = {
+				limit = {
+					province_id = 3283
+				}
+				change_province_name = "Baranya"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	croatia_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
 				OR = {
-					tag = KUK 
+					tag = KUK
 					tag = DNB
 				}
 			}
 			OR = {
 				has_global_flag = croatia_rename_hun
 				has_global_flag = croatia_rename_cro
-				has_global_flag = serbia_rename_cro
+				has_global_flag = croatia_rename_ser
+				has_global_flag = croatia_rename_tur
 			}
 			owns = 771
 			owns = 772
 			owns = 777
 			owns = 779
+			owns = 3283
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = croatia_rename_hun
 			clr_global_flag = croatia_rename_cro
-			clr_global_flag = serbia_rename_cro
-			771 = { 
-				change_province_name = "Agram " 
+			clr_global_flag = croatia_rename_ser
+			clr_global_flag = croatia_rename_tur
+			771 = {
+				change_province_name = "Agram"
 				state_scope = { change_region_name = "Kroatien-Slawonien" }
 			}
 			772 = { change_province_name = "Sissek" }
@@ -2274,12 +2625,62 @@ political_decisions = {
 			3289 = { change_province_name = "Csakathurn" }
 			777 = { change_province_name = "Poschegg" }
 			779 = { change_province_name = "Esseg" }
-			3283 = { change_province_name = "Branau" }
+			any_owned = {
+				limit = {
+					province_id = 3283
+				}
+				change_province_name = "Branau"
+			}
 		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	croatia_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			NOT = { has_global_flag = croatia_rename_tur }
+			owns = 771
+			owns = 772
+			owns = 777
+			owns = 779
+			owns = 3283
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = croatia_rename_tur
+			clr_global_flag = croatia_rename_hun
+			clr_global_flag = croatia_rename_cro
+			clr_global_flag = croatia_rename_ser
+			771 = {
+				change_province_name = "Zagrab"
+				state_scope = { change_region_name = "Kanije Eyalet" }
+			}
+			772 = { change_province_name = "Sisak" }
+			775 = { change_province_name = "Varadin" }
+			776 = { change_province_name = "Pakraç" }
+			3289 = { change_province_name = "Kanije" }
+			777 = { change_province_name = "Pojega" }
+			779 = { change_province_name = "Ösek" }
+			any_owned = {
+				limit = {
+					province_id = 3283
+				}
+				change_province_name = "Baranya"
+			}
+		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Lika ##
+
 	lika_rename_cro = {
 		picture = gtfo
 		potential = {
@@ -2293,26 +2694,27 @@ political_decisions = {
 			owns = 778
 			NOT = { has_global_flag = lika_rename_cro }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = lika_rename_cro
 			clr_global_flag = lika_rename_ita
 			clr_global_flag = lika_rename_ser
 			clr_global_flag = lika_rename_hun
-			774 = { change_province_name = "Slunj" 
+			774 = { change_province_name = "Slunj"
 				state_scope = { change_region_name = "Lika" }
 			}
 			773 = { change_province_name = "Senj" }
 			778 = { change_province_name = "Rijeka" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lika_rename_ser = {
 		picture = greater_serbia
 		potential = {
@@ -2323,26 +2725,27 @@ political_decisions = {
 			owns = 778
 			NOT = { has_global_flag = lika_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = lika_rename_ser
 			clr_global_flag = lika_rename_ita
 			clr_global_flag = lika_rename_cro
 			clr_global_flag = lika_rename_hun
-			774 = { change_province_name = "Slunj" 
+			774 = { change_province_name = "Slunj"
 				state_scope = { change_region_name = "Lika" }
 			}
 			773 = { change_province_name = "Senj" }
 			778 = { change_province_name = "Rijeka" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lika_rename_hun = {
 		picture = gtfo
 		potential = {
@@ -2353,26 +2756,27 @@ political_decisions = {
 			owns = 778
 			NOT = { has_global_flag = lika_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = lika_rename_hun
 			clr_global_flag = lika_rename_ita
 			clr_global_flag = lika_rename_cro
 			clr_global_flag = lika_rename_ser
-			774 = { change_province_name = "Szluin"  
+			774 = { change_province_name = "Szluin"
 				state_scope = { change_region_name = "Lika" }
 			}
 			773 = { change_province_name = "Zengg" }
 			778 = { change_province_name = "Fiume" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lika_rename_ita = {
 		picture = italian_dalmatia
 		potential = {
@@ -2382,33 +2786,34 @@ political_decisions = {
 			owns = 778
 			NOT = { has_global_flag = lika_rename_ita }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = lika_rename_ita
 			clr_global_flag = lika_rename_cro
 			clr_global_flag = lika_rename_ser
 			clr_global_flag = lika_rename_hun
-			774 = { change_province_name = "Slugna"  
+			774 = { change_province_name = "Slugna"
 				state_scope = { change_region_name = "Licca" }
 			}
 			773 = { change_province_name = "Segna" }
 			778 = { change_province_name = "Fiume" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lika_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
 				OR = {
-					tag = KUK 
+					tag = KUK
 					tag = DNB
 				}
 			}
@@ -2422,27 +2827,29 @@ political_decisions = {
 			owns = 774
 			owns = 778
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = lika_rename_ita
 			clr_global_flag = lika_rename_cro
 			clr_global_flag = lika_rename_ser
 			clr_global_flag = lika_rename_hun
-			774 = { change_province_name = "Sluin"  
+			774 = { change_province_name = "Sluin"
 				state_scope = { change_region_name = "Lika" }
 			}
 			773 = { change_province_name = "Zengg" }
 			778 = { change_province_name = "Sankt Veit" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Dalmatia ##
+
 	dalmatia_rename_cro = {
 		picture = italian_dalmatia
 		potential = {
@@ -2455,27 +2862,28 @@ political_decisions = {
 			owns = 2582
 			NOT = { has_global_flag = dalmatia_rename_cro }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = dalmatia_rename_cro
 			clr_global_flag = dalmatia_rename_ita
 			clr_global_flag = dalmatia_rename_ser
-			780 = { 
-				change_province_name = "Split" 
+			780 = {
+				change_province_name = "Split"
 				state_scope = { change_region_name = "Dalmacija" }
 			}
 			781 = { change_province_name = "Zadar" }
 			782 = { change_province_name = "Dubrovnik" }
 			2582 = { change_province_name = "Kotor" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	dalmatia_rename_ser = {
 		picture = greater_serbia
 		potential = {
@@ -2486,27 +2894,28 @@ political_decisions = {
 			owns = 2582
 			NOT = { has_global_flag = dalmatia_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = dalmatia_rename_ser
 			clr_global_flag = dalmatia_rename_ita
 			clr_global_flag = dalmatia_rename_cro
-			780 = { 
-				change_province_name = "Split" 
+			780 = {
+				change_province_name = "Split"
 				state_scope = { change_region_name = "Dalmacija" }
 			}
 			781 = { change_province_name = "Zadar" }
 			782 = { change_province_name = "Dubrovnik" }
 			2582 = { change_province_name = "Kotor" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	dalmatia_rename_ita = {
 		picture = italian_dalmatia
 		potential = {
@@ -2516,34 +2925,35 @@ political_decisions = {
 			owns = 2582
 			NOT = { has_global_flag = dalmatia_rename_ita }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = dalmatia_rename_ita
 			clr_global_flag = dalmatia_rename_cro
 			clr_global_flag = dalmatia_rename_ser
-			780 = { 
-				change_province_name = "Spalato" 
+			780 = {
+				change_province_name = "Spalato"
 				state_scope = { change_region_name = "Dalmazia" }
 			}
 			781 = { change_province_name = "Zara" }
 			782 = { change_province_name = "Ragusa" }
 			2582 = { change_province_name = "Càttaro" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	dalmatia_rename_aus = {
 		picture = italian_dalmatia
 		potential = {
 			is_culture_group = germanic
 			NOT = {
 				OR = {
-					tag = KUK 
+					tag = KUK
 					tag = DNB
 				}
 			}
@@ -2556,28 +2966,30 @@ political_decisions = {
 			owns = 781
 			owns = 2582
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = dalmatia_rename_ita
 			clr_global_flag = dalmatia_rename_cro
 			clr_global_flag = dalmatia_rename_ser
-			780 = { 
-				change_province_name = "Spalato" 
+			780 = {
+				change_province_name = "Spalato"
 				state_scope = { change_region_name = "Dalmatien" }
 			}
 			781 = { change_province_name = "Zara" }
 			782 = { change_province_name = "Ragusa" }
 			2582 = { change_province_name = "Cattaro" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Vojvodina ##
+
 	vojvodina_rename_ser = {
 		picture = greater_serbia
 		potential = {
@@ -2591,32 +3003,47 @@ political_decisions = {
 			owns = 792
 			NOT = { has_global_flag = vojvodina_rename_ser }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = vojvodina_rename_ser
 			clr_global_flag = vojvodina_rename_hun
-		791 = { 
-			change_province_name = "Mitrovica" 
-			state_scope = { change_region_name = "Vojvodina" }
+			clr_global_flag = vojvodina_rename_tur
+			any_owned = {
+				limit = {
+					province_id = 791
+					owner = { owns = 3321 }
+				}
+				change_province_name = "Sremska Mitrovica"
+				3321 = { change_province_name = "Kosovska Mitrovica" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 791
+					owner = { NOT = { owns = 3321 } }
+				}
+				change_province_name = "Mitrovica"
+			}
+			792 = {
+				change_province_name = "Pancevo"
+				state_scope = { change_region_name = "Vojvodina" }
+			}
+			2538 = { change_province_name = "Novi Sad" }
+			3319 = { change_province_name = "Kikinda" }
+			3309 = { change_province_name = "Subotica" }
 		}
-		792 = { change_province_name = "Pancevo" }
-		2538 = { change_province_name = "Novi Sad" }
-			prestige = 2
-		3319 = { change_province_name = "Kikinda" }
-		3309 = { change_province_name = "Subotica" }
-		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	vojvodina_rename_hun = {
 		picture = gtfo
 		potential = {
-			OR = { 
+			OR = {
 				primary_culture = hungarian
 				tag = KUK
 				tag = DNB
@@ -2626,76 +3053,113 @@ political_decisions = {
 			owns = 792
 			NOT = { has_global_flag = vojvodina_rename_hun }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = vojvodina_rename_hun
 			clr_global_flag = vojvodina_rename_ser
-			prestige = 2
-		791 = { 
-			change_province_name = "Szávaszentdemeter"
-			state_scope = { change_region_name = "Tartomány" }
-		} 
-		792 = { change_province_name = "Pancsova" }
-		2538 = { change_province_name = "Újvidék" }
-		3319 = { change_province_name = "Nagykikinda" }
-		3309 = { change_province_name = "Szabadka" }
+			clr_global_flag = vojvodina_rename_tur
+			791 = {
+				change_province_name = "Szávaszentdemeter"
+				state_scope = { change_region_name = "Tartomány" }
+			}
+			792 = { change_province_name = "Pancsova" }
+			2538 = { change_province_name = "Újvidék" }
+			3319 = { change_province_name = "Nagykikinda" }
+			3309 = { change_province_name = "Szabadka" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	vojvodina_rename_aus = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
 			NOT = {
 				OR = {
-					tag = KUK 
+					tag = KUK
 					tag = DNB
 				}
 			}
 			OR = {
 				has_global_flag = vojvodina_rename_ser
 				has_global_flag = vojvodina_rename_hun
+				has_global_flag = vojvodina_rename_tur
 			}
 			owns = 2538
 			owns = 791
 			owns = 792
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = vojvodina_rename_hun
 			clr_global_flag = vojvodina_rename_ser
-		791 = { 
-			change_province_name = "Syrmisch"
-			state_scope = { change_region_name = "Wojwodina" }
+			clr_global_flag = vojvodina_rename_tur
+			791 = {
+				change_province_name = "Syrmisch"
+				state_scope = { change_region_name = "Wojwodina" }
+			}
+			792 = { change_province_name = "Pantschowa" }
+			2538 = { change_province_name = "Neusatz" }
+			3319 = { change_province_name = "Groß Kikinda" }
+			3309 = { change_province_name = "Maria-Theresiopel" }
 		}
-		792 = { change_province_name = "Pantschowa" }
-		2538 = { change_province_name = "Neusatz" }
-		3319 = { change_province_name = "Groß Kikinda" }
-		3309 = { change_province_name = "Maria-Theresiopel" }
+
+		ai_will_do = { factor = 1 }
+	}
+
+	vojvodina_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 2538
+			owns = 791
+			owns = 792
+			NOT = { has_global_flag = vojvodina_rename_tur }
 		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = vojvodina_rename_tur
+			clr_global_flag = vojvodina_rename_hun
+			clr_global_flag = vojvodina_rename_ser
+			791 = {
+				change_province_name = "Dimitrofça"
+				state_scope = { change_region_name = "Beçkerek Sancagi" }
+			}
+			792 = { change_province_name = "Pançova" }
+			2538 = { change_province_name = "Varadin" }
+			3319 = { change_province_name = "Beçkerek" }
+			3309 = { change_province_name = "Sobotka" }
+		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ### GERMANY ###
-## Schleswig-Holstein ##	
+## Schleswig-Holstein ##
+
 	swh_rename = {
 		picture = gtfo
 		potential = {
 			OR = {
 				AND = {
 					is_culture_group = germanic
-					OR = { 
+					OR = {
 						AND = { owns = 369 NOT = { has_global_flag = german_renamed_holstein } }
 						AND = { owns = 370 NOT = { has_global_flag = german_renamed_schleswig } }
 					}
@@ -2705,16 +3169,16 @@ political_decisions = {
 					OR = {
 						AND = { owns = 369 NOT = { has_global_flag = scandinavian_renamed_holstein } }
 						AND = { owns = 370 NOT = { has_global_flag = scandinavian_renamed_schleswig } }
-					}	
+					}
 				}
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			###German###
 			random_owned = {
@@ -2731,12 +3195,12 @@ political_decisions = {
 					}
 				}
 				529 = { change_province_name = "Lauenburg" }
-				owner = { 
-					set_global_flag = german_renamed_holstein 
-					clr_global_flag = scandinavian_renamed_holstein 
+				owner = {
+					set_global_flag = german_renamed_holstein
+					clr_global_flag = scandinavian_renamed_holstein
 				}
 			}
-			
+
 			random_owned = {
 				limit = {
 					province_id = 370
@@ -2751,9 +3215,9 @@ political_decisions = {
 					}
 				}
 				371 = { change_province_name = "Apenrade" }
-				owner = { 
-					set_global_flag = german_renamed_schleswig 
-					clr_global_flag = scandinavian_renamed_schleswig 
+				owner = {
+					set_global_flag = german_renamed_schleswig
+					clr_global_flag = scandinavian_renamed_schleswig
 				}
 			}
 			###Danish###
@@ -2771,7 +3235,7 @@ political_decisions = {
 					}
 				}
 				529 = { change_province_name = "Lauenborg" }
-				owner = { 
+				owner = {
 					set_global_flag = scandinavian_renamed_holstein
 					clr_global_flag = german_renamed_holstein
 				}
@@ -2790,16 +3254,18 @@ political_decisions = {
 					}
 				}
 				371 = { change_province_name = "Aabenraa" }
-				owner = { 
+				owner = {
 					set_global_flag = scandinavian_renamed_schleswig
 					clr_global_flag = german_renamed_schleswig
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Pomerania ##
+
 	swedish_rename_pomerania = {
 		picture = gtfo
 		potential = {
@@ -2811,18 +3277,18 @@ political_decisions = {
 			owns = 546
 			NOT = { has_global_flag = swedish_rename_pomerania }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = swedish_rename_pomerania
 			clr_global_flag = polish_rename_pomerania
 			clr_global_flag = german_rename_pomerania
-			546 = { 
-				change_province_name = "Stejtin" 
+			546 = {
+				change_province_name = "Stejtin"
 				state_scope = { change_region_name = "Pommern" }
 			}
 			547 = { change_province_name = "Gripsskog" }
@@ -2830,6 +3296,7 @@ political_decisions = {
 			679 = { change_province_name = "Kohlberg" }
 			680 = { change_province_name = "Koslin" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -2842,18 +3309,18 @@ political_decisions = {
 				has_global_flag = german_rename_pomerania
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = swedish_rename_pomerania
 			clr_global_flag = polish_rename_pomerania
 			set_global_flag = german_rename_pomerania
-			546 = { 
-				change_province_name = "Stettin" 
+			546 = {
+				change_province_name = "Stettin"
 				state_scope = { change_region_name = "Pommern" }
 			}
 			547 = { change_province_name = "Greifswald" }
@@ -2861,9 +3328,10 @@ political_decisions = {
 			680 = { change_province_name = "Köslin" }
 			679 = { change_province_name = "Kolberg" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	polish_rename_pomerania = {
 		picture = gtfo
 		potential = {
@@ -2875,18 +3343,18 @@ political_decisions = {
 			owns = 546
 			NOT = { has_global_flag = polish_rename_pomerania }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = polish_rename_pomerania
 			clr_global_flag = swedish_rename_pomerania
 			clr_global_flag = german_rename_pomerania
-			546 = { 
-				change_province_name = "Szczecin" 
+			546 = {
+				change_province_name = "Szczecin"
 				state_scope = { change_region_name = "Zachodniopomorskie" }
 			}
 			547 = { change_province_name = "Gryfia" }
@@ -2894,10 +3362,12 @@ political_decisions = {
 			680 = { change_province_name = "Koszalin" }
 			679 = { change_province_name = "Kolobrzeg" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## East Brandenburg ##
+
 	german_rename_brandenburg = {
 		picture = gtfo
 		potential = {
@@ -2910,12 +3380,12 @@ political_decisions = {
 			has_global_flag = treaty_of_krakow
 			NOT = { has_global_flag = german_rename_brandenburg }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_brandenburg
 			clr_global_flag = polish_rename_brandenburg
@@ -2924,6 +3394,7 @@ political_decisions = {
 			552 = { change_province_name = "Cottbus" }
 			550 = { change_province_name = "Prenzlau" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -2942,12 +3413,12 @@ political_decisions = {
 			NOT = { has_global_flag = polish_rename_brandenburg }
 			has_global_flag = treaty_of_krakow
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = polish_rename_brandenburg
 			clr_global_flag = german_rename_brandenburg
@@ -2956,10 +3427,12 @@ political_decisions = {
 			552 = { change_province_name = "Chociebuz" }
 			550 = { change_province_name = "Przeslaw" }
 		}
+
 		ai_will_do = { factor = 1 }
-	}	
+	}
 
 ## Silesia ##
+
 	silesia_rename_german = {
 		picture = gtfo
 		potential = {
@@ -2973,31 +3446,31 @@ political_decisions = {
 			OR = {
 				AND = { owns = 682 NOT = { has_global_flag = prussian_silesia_rename_german } }
 				AND = { owns = 689 NOT = { has_global_flag = austrian_silesia_rename_german } }
-				
+
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 682
 				}
-				682 = { 
-					change_province_name = "Breslau" 
+				682 = {
+					change_province_name = "Breslau"
 					state_scope = { change_region_name = "Schlesien" }
 				}
 				683 = { change_province_name = "Waldenburg"  }
 				684 = { change_province_name = "Oppeln"  }
 				685 = { change_province_name = "Kattowitz"  }
 				3277 = { change_province_name = "Hultschin"  }
-				owner = { 
-					set_global_flag = prussian_silesia_rename_german 
-					clr_global_flag = prussian_silesia_rename_polish 
+				owner = {
+					set_global_flag = prussian_silesia_rename_german
+					clr_global_flag = prussian_silesia_rename_polish
 					clr_global_flag = prussian_silesia_rename_czech
 				}
 			}
@@ -3008,16 +3481,17 @@ political_decisions = {
 				689 = { change_province_name = "Teschen" }
 				688 = { change_province_name = "Troppau" }
 				2584 = { change_province_name = "Bielitz" }
-				owner = { 
-					set_global_flag = austrian_silesia_rename_german 
+				owner = {
+					set_global_flag = austrian_silesia_rename_german
 					clr_global_flag = austrian_silesia_rename_polish
 					clr_global_flag = austrian_silesia_rename_czech
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	silesia_rename_polish = {
 		picture = gtfo
 		potential = {
@@ -3034,18 +3508,18 @@ political_decisions = {
 				AND = { owns = 689 NOT = { has_global_flag = austrian_silesia_rename_polish } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 682
 				}
-				682 = { 
+				682 = {
 					change_province_name = "Wroclaw"
 					state_scope = { change_region_name = "Slask" }
 				}
@@ -3053,9 +3527,9 @@ political_decisions = {
 				684 = { change_province_name = "Opole"  }
 				685 = { change_province_name = "Katowice"  }
 				3277 = { change_province_name = "Hulczyn"  }
-				owner = { 
+				owner = {
 					set_global_flag = prussian_silesia_rename_polish
-					clr_global_flag = prussian_silesia_rename_german 
+					clr_global_flag = prussian_silesia_rename_german
 					clr_global_flag = prussian_silesia_rename_czech
 				}
 			}
@@ -3066,41 +3540,42 @@ political_decisions = {
 				689 = { change_province_name = "Cieszyn" }
 				688 = { change_province_name = "Opawa" }
 				2584 = { change_province_name = "Bielsko" }
-				owner = { 
+				owner = {
 					set_global_flag = austrian_silesia_rename_polish
 					clr_global_flag = austrian_silesia_rename_german
 					clr_global_flag = austrian_silesia_rename_czech
-					
+
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	silesia_rename_czech = {
 		picture = gtfo
 		potential = {
 			is_culture_group = czecho_slovak_culture_group
-			owns = 689 
+			owns = 689
 			owns = 3277
 			NOT = { has_global_flag = prussian_silesia_rename_czech }NOT = { has_global_flag = austrian_silesia_rename_czech }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 3277
 				}
 				3277 = { change_province_name = "Hlucín" }
-				owner = { 
+				owner = {
 					set_global_flag = prussian_silesia_rename_czech
 					clr_global_flag = prussian_silesia_rename_polish
-					clr_global_flag = prussian_silesia_rename_german 
+					clr_global_flag = prussian_silesia_rename_german
 				}
 			}
 			random_owned = {
@@ -3110,18 +3585,20 @@ political_decisions = {
 				689 = { change_province_name = "Tesin" }
 				688 = { change_province_name = "Opava" }
 				2584 = { change_province_name = "Bílsko" }
-				owner = { 
+				owner = {
 					set_global_flag = austrian_silesia_rename_czech
-					clr_global_flag = austrian_silesia_rename_polish 
-					clr_global_flag = austrian_silesia_rename_german 
-					
+					clr_global_flag = austrian_silesia_rename_polish
+					clr_global_flag = austrian_silesia_rename_german
+
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## West Prussia ##
+
 	west_prussia_rename_german = {
 		picture = gtfo
 		potential = {
@@ -3129,15 +3606,15 @@ political_decisions = {
 			OR = {
 				AND = { owns = 691 NOT = { has_global_flag = west_prussia_rename_german } }
 				AND = { owns = 690 NOT = { has_global_flag = danzig_rename_german } }
-				
+
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
@@ -3145,30 +3622,31 @@ political_decisions = {
 				}
 				690 = { change_province_name = "Danzig" }
 				693 = { change_province_name = "Elbing" }
-				owner = { 
-					set_global_flag = danzig_rename_german 
-					clr_global_flag = danzig_rename_polish 
+				owner = {
+					set_global_flag = danzig_rename_german
+					clr_global_flag = danzig_rename_polish
 				}
 			}
 			random_owned = {
 				limit = {
 					province_id = 691
 				}
-				691 = { 
-					change_province_name = "Tuchel" 
+				691 = {
+					change_province_name = "Tuchel"
 					state_scope = { change_region_name = "Westpreußen" }
 				}
 				694 = { change_province_name = "Thorn"  }
 				692 = { change_province_name = "Deutsch Krone" }
-				owner = { 
-					set_global_flag = west_prussia_rename_german 
+				owner = {
+					set_global_flag = west_prussia_rename_german
 					clr_global_flag = west_prussia_rename_polish
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	west_prussia_rename_polish = {
 		picture = gtfo
 		potential = {
@@ -3185,40 +3663,42 @@ political_decisions = {
 				AND = { owns = 690 NOT = { has_global_flag = danzig_rename_polish } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 690 }
 				690 = { change_province_name = "Gdánsk" }
 				693 = { change_province_name = "Elblag" }
-				owner = { 
+				owner = {
 					set_global_flag = danzig_rename_polish
-					clr_global_flag = danzig_rename_german 
+					clr_global_flag = danzig_rename_german
 				}
 			}
 			random_owned = {
 				limit = { province_id = 691 }
-				691 = { 
-					change_province_name = "Tuchola" 
+				691 = {
+					change_province_name = "Tuchola"
 					state_scope = { change_region_name = "Pomorskie" }
 				}
 				694 = { change_province_name = "Torun"  }
 				692 = { change_province_name = "Walcz" }
-				owner = { 
+				owner = {
 					set_global_flag = west_prussia_rename_polish
 					clr_global_flag = west_prussia_rename_german
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
-## East Prussia ##	
+## East Prussia ##
+
 	polish_rename_eastprussia = {
 		picture = gtfo
 		potential = {
@@ -3233,23 +3713,24 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = polish_rename_eastprussia }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = polish_rename_eastprussia
 			clr_global_flag = russia_rename_eastprussia
 			clr_global_flag = german_rename_eastprussia
-			695 = { 
-				change_province_name = "Królewiec" 
+			695 = {
+				change_province_name = "Królewiec"
 				state_scope = { change_region_name = "Warmia-Masuria" }
 			}
 			696 = { change_province_name = "Olsztyn" }
 			697 = { change_province_name = "Ostróda" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3268,13 +3749,12 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = polish_rename_memel }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = polish_rename_memel
 			clr_global_flag = russian_rename_memel
@@ -3283,6 +3763,7 @@ political_decisions = {
 			698 = { change_province_name = "Klajpeda" }
 			3380 = { change_province_name = "Tylza" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3293,23 +3774,24 @@ political_decisions = {
 			owns = 695
 			NOT = { has_global_flag = german_rename_eastprussia }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = polish_rename_eastprussia
 			clr_global_flag = russia_rename_eastprussia
 			set_global_flag = german_rename_eastprussia
-			695 = { 
-				change_province_name = "Königsberg" 
+			695 = {
+				change_province_name = "Königsberg"
 				state_scope = { change_region_name = "Ostpreußen" }
 			}
 			696 = { change_province_name = "Allenstein" }
 			697 = { change_province_name = "Osterode" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3321,13 +3803,12 @@ political_decisions = {
 			is_culture_group = germanic
 			NOT = { has_global_flag = german_rename_memel }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = polish_rename_memel
 			set_global_flag = german_rename_memel
@@ -3336,6 +3817,7 @@ political_decisions = {
 			698 = { change_province_name = "Memel" }
 			3380 = { change_province_name = "Tilsit" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3346,24 +3828,36 @@ political_decisions = {
 			owns = 695
 			NOT = { has_global_flag = russian_rename_eastprussia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = polish_rename_eastprussia
 			set_global_flag = russia_rename_eastprussia
 			clr_global_flag = german_rename_eastprussia
-			695 = { 
-				change_province_name = "Kaliningrad" 
+			any_owned = {
+				limit = {
+					province_id = 695
+					owner = { has_country_flag = names_of_the_revolution }
+				}
+				change_province_name = "Kaliningrad"
 				state_scope = { change_region_name = "Kaliningrad" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 695
+					owner = { NOT = { has_country_flag = names_of_the_revolution } }
+				}
+				change_province_name = "Korolevets"
+				state_scope = { change_region_name = "Vostóchnaya Prússiya" }
 			}
 			696 = { change_province_name = "Olsztyn" }
 			697 = { change_province_name = "Ostroda" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3375,13 +3869,12 @@ political_decisions = {
 			is_culture_group = east_slavic
 			NOT = { has_global_flag = russian_rename_memel }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = polish_rename_memel
 			clr_global_flag = german_rename_memel
@@ -3390,6 +3883,7 @@ political_decisions = {
 			698 = { change_province_name = "Klaypeda" }
 			3380 = { change_province_name = "Tilsit" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -3401,13 +3895,12 @@ political_decisions = {
 			is_culture_group = baltic
 			NOT = { has_global_flag = lit_rename_memel }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = polish_rename_memel
 			clr_global_flag = german_rename_memel
@@ -3416,10 +3909,12 @@ political_decisions = {
 			698 = { change_province_name = "Klaipeda" }
 			3380 = { change_province_name = "Tilže" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Posen ##
+
 	posen_rename_polish = {
 		picture = gtfo
 		potential = {
@@ -3434,16 +3929,16 @@ political_decisions = {
 			owns = 699
 			NOT = { has_global_flag = posen_rename_polish }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = posen_rename_polish
 			clr_global_flag = posen_rename_german
-			699 = { 
+			699 = {
 				change_province_name = "Poznán"
 				state_scope = { change_region_name = "Poznán" }
 			}
@@ -3451,9 +3946,10 @@ political_decisions = {
 			701 = { change_province_name = "Gniezno" }
 			3281 = { change_province_name = "Wschowa" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	posen_rename_german = {
 		picture = gtfo
 		potential = {
@@ -3461,16 +3957,16 @@ political_decisions = {
 			owns = 699
 			NOT = { has_global_flag = posen_rename_german }
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = posen_rename_german
 			clr_global_flag = posen_rename_polish
-			699 = { 
+			699 = {
 				change_province_name = "Posen"
 				state_scope = { change_region_name = "Posen" }
 			}
@@ -3478,11 +3974,12 @@ political_decisions = {
 			701 = { change_province_name = "Gnesen" }
 			3281 = { change_province_name = "Fraustadt" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Rhineland ##
-	
+
 	france_rename_rhine = {
 		picture = gtfo
 		potential = {
@@ -3506,16 +4003,16 @@ political_decisions = {
 				AND = { owns = 398 NOT = { has_global_flag = france_rename_arlon } }
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 575 }
-				575 = { 
+				575 = {
 					change_province_name = "Cologne"
 					state_scope = { change_region_name = "Rhénanie"  }
 				}
@@ -3528,7 +4025,7 @@ political_decisions = {
 				owner = { clr_global_flag = dutch_rename_rhine }
 				owner = { clr_global_flag = german_rename_rhine }
 			}
-			
+
 			random_owned = {
 				limit = { province_id = 3302 }
 				3302 = { change_province_name = "Champ-de-Bouleaux" }
@@ -3539,14 +4036,14 @@ political_decisions = {
 
 			random_owned = {
 				limit = { province_id = 573 }
-				573 = { 
+				573 = {
 					change_province_name = "Sarrebruck"
 					state_scope = { change_region_name = "Sarre et Mont Tonnerre"  }
 				}
 				owner = { set_global_flag = france_rename_prussian_pfalz }
 				owner = { clr_global_flag = german_rename_prussian_pfalz }
 			}
-			
+
 			random_owned = {
 				limit = { province_id = 571 }
 				571 = { change_province_name = "Caseloutre" }
@@ -3580,7 +4077,7 @@ political_decisions = {
 			random_owned = {
 				limit = { province_id = 398 }
 				398 = { change_province_name = "Arlon" }
-				owner = { 
+				owner = {
 					set_global_flag = france_rename_arlon
 					clr_global_flag = dutch_rename_arlon
 					clr_global_flag = german_rename_arlon
@@ -3590,7 +4087,7 @@ political_decisions = {
 			random_owned = {
 				limit = { province_id = 395 }
 				395 = { change_province_name = "Liège" }
-				owner = { 
+				owner = {
 					set_global_flag = france_rename_liege
 					clr_global_flag = dutch_rename_liege
 					clr_global_flag = german_rename_liege
@@ -3623,7 +4120,7 @@ political_decisions = {
 			random_owned = {
 				limit = { province_id = 393 }
 				393 = { change_province_name = "Tournai" }
-				owner = { 
+				owner = {
 					set_global_flag = france_rename_tournai
 					clr_global_flag = dutch_rename_tournai
 					clr_global_flag = german_rename_tournai
@@ -3632,20 +4129,21 @@ political_decisions = {
 
 			random_owned = {
 				limit = { province_id = 394 }
-				394 = { 
-					change_province_name = "Charleroi" 
+				394 = {
+					change_province_name = "Charleroi"
 					state_scope = { change_region_name = "Wallonie" }
 				}
-				owner = { 
+				owner = {
 					set_global_flag = france_rename_charleroi
 					clr_global_flag = dutch_rename_charleroi
 					clr_global_flag = german_rename_charleroi
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
-	}	
-	
+	}
+
 	german_rename_rhine = {
 		picture = gtfo
 		potential = {
@@ -3668,17 +4166,17 @@ political_decisions = {
 				AND = { owns = 3306 NOT = { has_global_flag = german_rename_hesse_homburg } }
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { province_id = 381 }
 				381 = { change_province_name = "Limburg" }
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_limburg
 					clr_global_flag = dutch_rename_limburg
 				}
@@ -3707,7 +4205,7 @@ political_decisions = {
 
 			random_owned = {
 				limit = { province_id = 573 }
-				573 = { 
+				573 = {
 					change_province_name = "Saarbrücken"
 					state_scope = { change_region_name = "Pfalz" }
 				}
@@ -3718,7 +4216,7 @@ political_decisions = {
 			random_owned = {
 				limit = { province_id = 575 }
 				396 = { change_province_name = "Eupen-Malmedy" }
-				575 = { 
+				575 = {
 					change_province_name = "Cöln"
 					state_scope = { change_region_name = "Rheinland" }
 				}
@@ -3746,21 +4244,21 @@ political_decisions = {
 				owner = { clr_global_flag = france_rename_hesse_homburg }
 				owner = { set_global_flag = german_rename_hesse_homburg }
 			}
-			
+
 			random_owned = {
 				limit = { province_id = 398 }
 				398 = { change_province_name = "Arel" }
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_arlon
 					clr_global_flag = dutch_rename_arlon
 					clr_global_flag = france_rename_arlon
 				}
 			}
-			
+
 			random_owned = {
 				limit = { province_id = 395 }
 				395 = { change_province_name = "Lüttich" }
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_liege
 					clr_global_flag = dutch_rename_liege
 					clr_global_flag = france_rename_liege
@@ -3770,10 +4268,10 @@ political_decisions = {
 				limit = {
 					province_id = 387
 				}
-				387 = { 
+				387 = {
 					change_province_name = "Brüssel"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_brussels
 					clr_global_flag = france_rename_brussels
 					clr_global_flag = dutch_rename_arlon
@@ -3783,10 +4281,10 @@ political_decisions = {
 				limit = {
 					province_id = 398
 				}
-				398 = { 
+				398 = {
 					change_province_name = "Bastenach"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_arlon
 					clr_global_flag = france_rename_arlon
 					clr_global_flag = dutch_rename_arlon
@@ -3796,10 +4294,10 @@ political_decisions = {
 				limit = {
 					province_id = 392
 				}
-				392 = { 
+				392 = {
 					change_province_name = "Namür"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_namur
 					clr_global_flag = france_rename_namur
 					clr_global_flag = dutch_rename_namur
@@ -3809,10 +4307,10 @@ political_decisions = {
 				limit = {
 					province_id = 393
 				}
-				393 = { 
+				393 = {
 					change_province_name = "Dornick"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_tournai
 					clr_global_flag = france_rename_tournai
 					clr_global_flag = dutch_rename_tournai
@@ -3822,21 +4320,21 @@ political_decisions = {
 				limit = {
 					province_id = 394
 				}
-				394 = { 
-					change_province_name = "Karolingen" 
+				394 = {
+					change_province_name = "Karolingen"
 					state_scope = { change_region_name = "Wallonien" }
 				}
-				owner = { 
+				owner = {
 					set_global_flag = german_rename_charleroi
 					clr_global_flag = france_rename_charleroi
 					clr_global_flag = dutch_rename_charleroi
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	dutch_rename_rhine = {
 		picture = gtfo
 		potential = {
@@ -3845,21 +4343,21 @@ political_decisions = {
 				primary_culture = dutch
 			}
 			OR = {
-				AND = { 
-					owns = 575 
-					has_global_flag = france_rename_rhine 
+				AND = {
+					owns = 575
+					has_global_flag = france_rename_rhine
 				}
-				AND = { 
-					owns = 397 
-					has_global_flag = france_rename_luxemburg 
+				AND = {
+					owns = 397
+					has_global_flag = france_rename_luxemburg
 				}
-				AND = { 
-					owns = 575 
-					NOT = { has_global_flag = dutch_rename_rhine } 
+				AND = {
+					owns = 575
+					NOT = { has_global_flag = dutch_rename_rhine }
 				}
-				AND = { 
-					owns = 397 
-					NOT = { has_global_flag = dutch_rename_luxemburg } 
+				AND = {
+					owns = 397
+					NOT = { has_global_flag = dutch_rename_luxemburg }
 				}
 				AND = { owns = 381 owns = 387 NOT = { has_global_flag = dutch_rename_limburg } }
 				AND = { owns = 387 NOT = { has_global_flag = dutch_rename_brussels } }
@@ -3871,20 +4369,21 @@ political_decisions = {
 				AND = { owns = 3318 NOT = { has_global_flag = dutch_rename_arel } }
 			}
 		}
-		
+
 		allow = {
 			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 387
 				}
-				387 = { 
+				387 = {
 					change_province_name = "Brussel"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_brussels
 					clr_global_flag = france_rename_brussels
 					clr_global_flag = german_rename_arlon
@@ -3895,10 +4394,10 @@ political_decisions = {
 					province_id = 381
 					owner = { owns = 387 }
 				}
-				381 = { 
+				381 = {
 					change_province_name = "Maastricht"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_limburg
 					clr_global_flag = german_rename_limburg
 				}
@@ -3907,10 +4406,10 @@ political_decisions = {
 				limit = {
 					province_id = 398
 				}
-				398 = { 
+				398 = {
 					change_province_name = "Bastenaken"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_arlon
 					clr_global_flag = france_rename_arlon
 					clr_global_flag = german_rename_arlon
@@ -3920,10 +4419,10 @@ political_decisions = {
 				limit = {
 					province_id = 3318
 				}
-				3318 = { 
+				3318 = {
 					change_province_name = "Aarlen"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_arel
 					clr_global_flag = france_rename_arel
 					clr_global_flag = german_rename_arel
@@ -3933,10 +4432,10 @@ political_decisions = {
 				limit = {
 					province_id = 395
 				}
-				395 = { 
+				395 = {
 					change_province_name = "Luik"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_liege
 					clr_global_flag = france_rename_liege
 					clr_global_flag = german_rename_liege
@@ -3946,10 +4445,10 @@ political_decisions = {
 				limit = {
 					province_id = 392
 				}
-				392 = { 
+				392 = {
 					change_province_name = "Namen"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_namur
 					clr_global_flag = france_rename_namur
 					#clr_global_flag = german_rename_namur
@@ -3959,10 +4458,10 @@ political_decisions = {
 				limit = {
 					province_id = 393
 				}
-				393 = { 
+				393 = {
 					change_province_name = "Doornik"
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_tournai
 					clr_global_flag = france_rename_tournai
 					#clr_global_flag = german_rename_tournai
@@ -3972,11 +4471,11 @@ political_decisions = {
 				limit = {
 					province_id = 394
 				}
-				394 = { 
+				394 = {
 					change_province_name = "Karleskoning"
 					state_scope = { change_region_name = "Wallonië" }
 				}
-				owner = { 
+				owner = {
 					set_global_flag = dutch_rename_charleroi
 					clr_global_flag = france_rename_charleroi
 					clr_global_flag = german_rename_charleroi
@@ -3984,7 +4483,7 @@ political_decisions = {
 			}
 			random_owned = {
 				limit = { province_id = 575 }
-				575 = { 
+				575 = {
 					change_province_name = "Keulen"
 					state_scope = { change_region_name = "Rijnland" }
 				}
@@ -4004,12 +4503,13 @@ political_decisions = {
 				owner = { set_global_flag = dutch_rename_luxemburg }
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ### FRANCE ###
-## Savoy-Nice-Aosta ##	
-	
+## Savoy-Nice-Aosta ##
+
 	italian_renamed_savoy_aosta = {
 		picture = claim_aosta
 		potential = {
@@ -4019,25 +4519,25 @@ political_decisions = {
 				AND = { owns = 721 NOT = { has_global_flag = italian_renamed_aosta } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 466
 				}
 				465 = { change_province_name = "Ennèsia" }
-				466 = { 
-					change_province_name = "Ciamberì"  
+				466 = {
+					change_province_name = "Ciamberì"
 					state_scope = { change_region_name = "Savoia-Nizza" }
 				}
 				472 = { change_province_name = "Nizza" }
 				3362 = { change_province_name = "Robione" }
-				owner = { 
+				owner = {
 					set_global_flag = italian_renamed_savoy
 					clr_global_flag = french_renamed_savoy
 				}
@@ -4048,15 +4548,16 @@ political_decisions = {
 				}
 				721 = { change_province_name = "Aosta" }
 				3363 = { change_province_name = "Bardonecchia" }
-				owner = { 
-					set_global_flag = italian_renamed_aosta 
-					clr_global_flag = french_renamed_aosta 
+				owner = {
+					set_global_flag = italian_renamed_aosta
+					clr_global_flag = french_renamed_aosta
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	french_renamed_savoy_aosta = {
 		picture = claim_aosta
 		potential = {
@@ -4066,25 +4567,25 @@ political_decisions = {
 				AND = { owns = 721 NOT = { has_global_flag = french_renamed_aosta } }
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 466
 				}
 				465 = { change_province_name = "Annecy" }
-				466 = { 
-					change_province_name = "Chambéry"  
+				466 = {
+					change_province_name = "Chambéry"
 					state_scope = { change_region_name = "Savoie-Nice" }
 				}
 				472 = { change_province_name = "Nice" }
 				3362 = { change_province_name = "Roubion" }
-				owner = { 
+				owner = {
 					set_global_flag = french_renamed_savoy
 					clr_global_flag = italian_renamed_savoy
 				}
@@ -4095,12 +4596,13 @@ political_decisions = {
 				}
 				721 = { change_province_name = "Aoste" }
 				3363 = { change_province_name = "Bardonnèche" }
-				owner = { 
-					set_global_flag = french_renamed_aosta 
-					clr_global_flag = italian_renamed_aosta 
+				owner = {
+					set_global_flag = french_renamed_aosta
+					clr_global_flag = italian_renamed_aosta
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4117,12 +4619,12 @@ political_decisions = {
 			NOT = { has_global_flag = treaty_of_elass_lorraine }
 			war = no
 		}
-		
+
 		allow = {
 			prestige = 10
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			409 = {
 				change_province_name = "Straßburg"
@@ -4138,21 +4640,21 @@ political_decisions = {
 			}
 			ALS = { government = colonial_company }
 			FRA_412 = { add_core = GER }
-			prestige = 5
+			prestige = 10
 			set_global_flag = germany_has_renamed_elsass
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	restore_alsace = {
 		potential = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
 			has_global_flag = germany_has_renamed_elsass
-			NOT = { 
-				OR = { 
+			NOT = {
+				OR = {
 					has_global_flag = treaty_of_elass_lorraine
 					has_global_flag = france_has_renamed_alsace
 				}
@@ -4163,21 +4665,21 @@ political_decisions = {
 			owns = 3322
 			war = no
 		}
-		
+
 		allow = {
 			prestige = 10
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			409 = {
 				change_province_name = "Strasbourg"
-				state_scope = { 
-					change_region_name = "Alsace-Lorraine" 
+				state_scope = {
+					change_region_name = "Alsace-Lorraine"
 				}
 			}
-			410 = { 
-				change_province_name = "Colmar" 
+			410 = {
+				change_province_name = "Colmar"
 			}
 			3322 = {
 				change_province_name = "Thionville"
@@ -4187,12 +4689,11 @@ political_decisions = {
 			prestige = 10
 			clr_global_flag = germany_has_renamed_elsass
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
 
-## Lorraine ##	
+## Lorraine ##
 	lorraine_rename = {
 		picture = gtfo
 		potential = {
@@ -4207,12 +4708,12 @@ political_decisions = {
 				}
 			}
 		}
-		
-		allow = {
-			war = no			state_n_government = 1
 
+		allow = {
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
 			###German###
 			random_owned = {
@@ -4232,7 +4733,7 @@ political_decisions = {
 					clr_global_flag = french_renamed_lorraine
 				}
 			}
-			
+
 			###French###
 			random_owned = {
 				limit = {
@@ -4246,16 +4747,18 @@ political_decisions = {
 				414 = { change_province_name = "Épinal" }
 				413 = { change_province_name = "Verdun" }
 				2622 = { change_province_name = "Bar-le-Duc" }
-				owner = { 
+				owner = {
 					set_global_flag = french_renamed_lorraine
 					clr_global_flag = german_renamed_lorraine
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Artois ##
+
 	rename_artois_NET = {
 		picture = NET_claim_artois
 		potential = {
@@ -4268,14 +4771,13 @@ political_decisions = {
 			owns = 404 #Cambrai
 			NOT = { has_global_flag = dutch_artois }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
-			nationalism_n_imperialism = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
-			prestige = 5
 			399 = { change_province_name = "Rijsel" }
 			401 = { change_province_name = "Atrecht" }
 			404 = {
@@ -4286,7 +4788,7 @@ political_decisions = {
 			clr_global_flag = french_artois
 			clr_global_flag = german_artois
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4299,14 +4801,13 @@ political_decisions = {
 			owns = 404 #Cambrai
 			NOT = { has_global_flag = german_artois }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
-			nationalism_n_imperialism = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
-			prestige = 5
 			399 = { change_province_name = "Ryssel" }
 			401 = { change_province_name = "Atrecht" }
 			404 = {
@@ -4317,7 +4818,7 @@ political_decisions = {
 			clr_global_flag = french_artois
 			set_global_flag = german_artois
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4330,14 +4831,13 @@ political_decisions = {
 			owns = 404 #Cambrai
 			NOT = { has_global_flag = french_artois }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
-			nationalism_n_imperialism = 1
+			war = no
+			state_n_government = 1
 		}
-		
+
 		effect = {
-			prestige = 5
 			set_global_flag = french_artois
 			399 = { change_province_name = "Lille" }
 			401 = { change_province_name = "Arras" }
@@ -4348,7 +4848,7 @@ political_decisions = {
 			clr_global_flag = dutch_artois
 			clr_global_flag = german_artois
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4362,20 +4862,19 @@ political_decisions = {
 			owns = 400 #Dunkirk
 			NOT = { has_global_flag = dutch_artois2 }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
+			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
-			prestige = 1
 			400 = { change_province_name = "Duinkerke" }
 			set_global_flag = dutch_artois2
 			clr_global_flag = french_artois2
 			clr_global_flag = german_artois2
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4386,20 +4885,19 @@ political_decisions = {
 			owns = 400 #Dunkirk
 			NOT = { has_global_flag = german_artois2 }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
+			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
-			prestige = 1
 			400 = { change_province_name = "Dünkirchen" }
 			clr_global_flag = dutch_artois2
 			clr_global_flag = french_artois2
 			set_global_flag = german_artois2
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4410,19 +4908,19 @@ political_decisions = {
 			owns = 400 #Dunkirk
 			NOT = { has_global_flag = french_artois2 }
 		}
-		
+
 		allow = {
-			is_greater_power = yes
+			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			400 = { change_province_name = "Dunkerque" }
 			clr_global_flag = dutch_artois2
 			clr_global_flag = german_artois2
 			set_global_flag = french_artois2
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4437,25 +4935,26 @@ political_decisions = {
 			owns = 366
 			NOT = { has_global_flag = german_rename_jylland }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_jylland
-			367 = { 
-				change_province_name = "Aalburg" 
+			367 = {
+				change_province_name = "Aalburg"
 				state_scope = { change_region_name = "Jutland" }
 			}
 			2557 = { change_province_name = "Esberg" }
 			366 = { change_province_name = "Arenhusen" }
 			368 = { change_province_name = "Vamdrup" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	scandinavian_rename_jylland = {
 		picture = gtfo
 		potential = {
@@ -4466,25 +4965,26 @@ political_decisions = {
 			owns = 366
 			has_global_flag = german_rename_jylland
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_jylland
-			367 = { 
-				change_province_name = "Aalborg" 
+			367 = {
+				change_province_name = "Aalborg"
 				state_scope = { change_region_name = "Jylland" }
 			}
 			2557 = { change_province_name = "Esbjerg" }
 			366 = { change_province_name = "Aarhus" }
 			368 = { change_province_name = "Vamdrup" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	german_rename_sjaelland = {
 		picture = gtfo
 		potential = {
@@ -4494,24 +4994,25 @@ political_decisions = {
 			owns = 374
 			NOT = { has_global_flag = german_rename_sjaelland }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_sjaelland
-			372 = { 
-				change_province_name = "Kopenhagen" 
+			372 = {
+				change_province_name = "Kopenhagen"
 				state_scope = { change_region_name = "Nord Seeland" }
 			}
 			373 = { change_province_name = "Ottensee" }
 			374 = { change_province_name = "Bornholm" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	scandinavian_rename_sjaelland = {
 		picture = gtfo
 		potential = {
@@ -4521,26 +5022,26 @@ political_decisions = {
 			owns = 374
 			has_global_flag = german_rename_sjaelland
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_sjaelland
-			372 = { 
-				change_province_name = "København" 
+			372 = {
+				change_province_name = "København"
 				state_scope = { change_region_name = "Sjaelland" }
 			}
 			373 = { change_province_name = "Odense" }
 			374 = { change_province_name = "Bornholm" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 ## Netherlands ##
-	
 	german_rename_friesland = {
 		picture = gtfo
 		potential = {
@@ -4549,19 +5050,20 @@ political_decisions = {
 			owns = 383
 			NOT = { has_global_flag = german_rename_friesland }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_friesland
 			385 = { change_province_name = "Leuwarten" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	beneluxian_rename_friesland = {
 		picture = gtfo
 		potential = {
@@ -4570,19 +5072,20 @@ political_decisions = {
 			owns = 383
 			has_global_flag = german_rename_friesland
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_friesland
 			385 = { change_province_name = "Leeuwarden" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	german_rename_holland = {
 		picture = gtfo
 		potential = {
@@ -4590,39 +5093,41 @@ political_decisions = {
 			owns = 382
 			NOT = { has_global_flag = german_rename_holland }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_holland
 			382 = { change_province_name = "Arnheim" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	beneluxian_rename_holland = {
 		picture = gtfo
 		potential = {
 			is_culture_group = beneluxian
 			owns = 382
-			has_global_flag = german_rename_holland 
+			has_global_flag = german_rename_holland
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_holland
 			382 = { change_province_name = "Arnhem" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	german_rename_zeeland = {
 		picture = gtfo
 		potential = {
@@ -4632,24 +5137,26 @@ political_decisions = {
 			owns = 378
 			NOT = { has_global_flag = german_rename_zeeland }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_zeeland
-			379 = { 
-				change_province_name = "Eindhofen" 
+			clr_global_flag = french_rename_zeeland
+			379 = {
+				change_province_name = "Eindhofen"
 				state_scope = { change_region_name = "Nord Brabant" }
 			}
 			378 = { change_province_name = "Mittelburg" }
-			3313 = { change_province_name = "Velno" }
+			3313 = { change_province_name = "Venlo" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	beneluxian_rename_zeeland = {
 		picture = gtfo
 		potential = {
@@ -4657,28 +5164,61 @@ political_decisions = {
 			owns = 3313
 			owns = 379
 			owns = 378
-			has_global_flag = german_rename_zeeland 
+			OR = {
+				has_global_flag = german_rename_zeeland
+				has_global_flag = french_rename_zeeland
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_zeeland
-			379 = { 
-				change_province_name = "Eindhoven" 
+			clr_global_flag = french_rename_zeeland
+			379 = {
+				change_province_name = "Eindhoven"
 				state_scope = { change_region_name = "Zeeland" }
 			}
 			378 = { change_province_name = "Middelburg" }
-			3313 = { change_province_name = "Velno" }
+			3313 = { change_province_name = "Venlo" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
+	french_rename_zeeland = {
+		picture = gtfo
+		potential = {
+			is_culture_group = french
+			owns = 3313
+			owns = 379
+			owns = 378
+			NOT = { has_global_flag = french_rename_zeeland }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = french_rename_zeeland
+			clr_global_flag = german_rename_zeeland
+			379 = {
+				change_province_name = "Eindhoven"
+				state_scope = { change_region_name = "Bouches-de-l'Escaut" }
+			}
+			378 = { change_province_name = "Middelbourg" }
+			3313 = { change_province_name = "Venlo" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Flanders ##
-	
 	german_rename_vlaanderen = {
 		picture = gtfo
 		potential = {
@@ -4689,15 +5229,15 @@ political_decisions = {
 			owns = 397
 			NOT = { has_global_flag = german_rename_vlaanderen }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_vlaanderen
-			387 = { 
+			387 = {
 				state_scope = { change_region_name = "Flandern" }
 			}
 			388 = { change_province_name = "Brügge" }
@@ -4705,6 +5245,7 @@ political_decisions = {
 			397 = { change_province_name = "Lützelburg" }
 			3386 = { change_province_name = "Löwen" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4717,22 +5258,23 @@ political_decisions = {
 			owns = 388
 			has_global_flag = german_rename_vlaanderen
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_vlaanderen
 			clr_global_flag = french_rename_vlaanderen
-			387 = { 
+			387 = {
 				state_scope = { change_region_name = "Vlaanderen" }
 			}
 			388 = { change_province_name = "Brugge" }
 			390 = { change_province_name = "Antwerpen" }
 			3386 = { change_province_name = "Leuven" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -4745,22 +5287,23 @@ political_decisions = {
 			owns = 388
 			NOT = { has_global_flag = french_rename_vlaanderen }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_vlaanderen
 			set_global_flag = french_rename_vlaanderen
-			387 = { 
+			387 = {
 				state_scope = { change_region_name = "Flandre" }
 			}
 			388 = { change_province_name = "Bruge" }
 			390 = { change_province_name = "Anvers" }
 			3386 = { change_province_name = "Louvain" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 }

--- a/TGC/decisions/Renaming-Decisions-RUS.txt
+++ b/TGC/decisions/Renaming-Decisions-RUS.txt
@@ -1,6 +1,7 @@
-political_decisions = { 
+political_decisions = {
 ### RUSSIA ###
 ## Masovia ##
+
 	mazovia_rename_polish = {
 		picture = gtfo
 		potential = {
@@ -15,18 +16,16 @@ political_decisions = {
 			owns = 706 #Warsaw
 			NOT = { has_global_flag = mazovia_rename_polish }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = mazovia_rename_polish
 			clr_global_flag = mazovia_rename_german
 			clr_global_flag = mazovia_rename_russian
-			prestige = 2
 			706 = {
 				change_province_name = "Warszawa"
 				state_scope = { change_region_name = "Mazowsze" }
@@ -36,29 +35,33 @@ political_decisions = {
 			717 = { change_province_name = "Kalisz" }
 			3323 = { change_province_name = "Konin" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	mazovia_rename_german = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { tag = DNB }
+			NOT = {
+				AND = {
+					tag = DNB
+					accepted_culture = polish
+				}
+			}
 			owns = 706 #Warsaw
 			NOT = { has_global_flag = mazovia_rename_german }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = mazovia_rename_german
 			clr_global_flag = mazovia_rename_polish
 			clr_global_flag = mazovia_rename_russian
-			prestige = 2
 			706 = {
 				change_province_name = "Warschau"
 				state_scope = { change_region_name = "Masowien" }
@@ -68,33 +71,29 @@ political_decisions = {
 			717 = { change_province_name = "Kalisch" }
 			3323 = { change_province_name = "Kotten" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	mazovia_rename_russian = {
 		picture = gtfo
 		potential = {
-			OR = {
-				primary_culture = russian
-				primary_culture = ukrainian
-			}
+			is_culture_group = east_slavic
 			owns = 706 #Warsaw
 			NOT = {
 				has_global_flag = mazovia_rename_russian
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = mazovia_rename_german
 			clr_global_flag = mazovia_rename_polish
 			set_global_flag = mazovia_rename_russian
-			prestige = 2
 			706 = {
 				change_province_name = "Varšava"
 				state_scope = { change_region_name = "Varšava" }
@@ -104,15 +103,20 @@ political_decisions = {
 			717 = { change_province_name = "Kalish" }
 			3323 = { change_province_name = "Konin" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Poldachia ##
+
 	poldachia_rename_polish = {
 		picture = gtfo
 		potential = {
 			OR = {
-				primary_culture = polish
+				AND = {
+					primary_culture = polish
+					is_vassal = no
+				}
 				AND = {
 					tag = DNB
 					accepted_culture = polish
@@ -122,18 +126,16 @@ political_decisions = {
 			owns = 719 #Bialystok
 			NOT = { has_global_flag = poldachia_rename_polish }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = poldachia_rename_polish
 			clr_global_flag = poldachia_rename_german
 			clr_global_flag = poldachia_rename_russian
-			prestige = 2
 			719 = {
 				change_province_name = "Bialystok"
 				state_scope = { change_region_name = "Podlasie" }
@@ -141,29 +143,38 @@ political_decisions = {
 			708 = { change_province_name = "Plock" }
 			709 = { change_province_name = "Lomza" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	poldachia_rename_german = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { tag = DNB }
-			owns = 719 #Bialystok
+			NOT = {
+				AND = {
+					tag = DNB
+					accepted_culture = polish
+				}
+			}
+			OR = {
+				owns = 719 #Bialystok
+				719 = {
+					vassal_of = THIS
+				}
+			}
 			NOT = { has_global_flag = poldachia_rename_german }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = poldachia_rename_german
 			clr_global_flag = poldachia_rename_polish
 			clr_global_flag = poldachia_rename_russian
-			prestige = 2
 			719 = {
 				change_province_name = "Bjelostock"
 				state_scope = { change_region_name = "Podlachien" }
@@ -171,33 +182,28 @@ political_decisions = {
 			708 = { change_province_name = "Plotzk" }
 			709 = { change_province_name = "Lumbsee" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	poldachia_rename_russian = {
 		picture = gtfo
 		potential = {
-			OR = {
-				primary_culture = russian
-				primary_culture = ukrainian
-			}
+			is_culture_group = east_slavic
 			owns = 719 #Bialystok
-			NOT = {
-				has_global_flag = poldachia_rename_russian
-			}
+			NOT = {	has_global_flag = poldachia_rename_russian }
+			is_vassal = no
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = poldachia_rename_russian
 			clr_global_flag = poldachia_rename_german
 			clr_global_flag = poldachia_rename_polish
-			prestige = 2
 			719 = {
 				change_province_name = "Belastok"
 				state_scope = { change_region_name = "Belastok" }
@@ -205,36 +211,36 @@ political_decisions = {
 			708 = { change_province_name = "Plotsk" }
 			709 = { change_province_name = "Lomzha" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lit_poldachia_rename_lit = {
 		picture = gtfo
 		potential = {
 			is_culture_group = baltic
 			owns = 707 #Suwalki
-			owns = 3381 #Lipsk
+			owns = 3381 #Augustov
 			NOT = { has_global_flag = lit_poldachia_rename_lit }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = lit_poldachia_rename_lit
 			clr_global_flag = lit_poldachia_rename_polish
 			clr_global_flag = lit_poldachia_rename_german
 			clr_global_flag = lit_poldachia_rename_russian
-			prestige = 2
 			707 = { change_province_name = "Suvalki" }
-			3381 = { change_province_name = "Liepine" }
+			3381 = { change_province_name = "Augustavas" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lit_poldachia_rename_polish = {
 		picture = gtfo
 		potential = {
@@ -248,88 +254,95 @@ political_decisions = {
 				tag = PLC
 			}
 			owns = 707 #Suwalki
-			owns = 3381 #Lipsk
+			owns = 3381 #Augustov
 			NOT = { has_global_flag = lit_poldachia_rename_polish }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = lit_poldachia_rename_polish
 			clr_global_flag = lit_poldachia_rename_german
 			clr_global_flag = lit_poldachia_rename_russian
 			clr_global_flag = lit_poldachia_rename_lit
-			prestige = 2
 			707 = { change_province_name = "Suwalki" }
-			3381 = { change_province_name = "Lipsk" }
+			3381 = { change_province_name = "Augustów" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lit_poldachia_rename_german = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { tag = DNB }
+			NOT = {
+				AND = {
+					tag = DNB
+					accepted_culture = polish
+				}
+			}
 			owns = 707 #Suwalki
-			owns = 3381 #Lipsk
+			owns = 3381 #Augustov
 			NOT = { has_global_flag = lit_poldachia_rename_german }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = lit_poldachia_rename_german
 			clr_global_flag = lit_poldachia_rename_polish
 			clr_global_flag = lit_poldachia_rename_russian
 			clr_global_flag = lit_poldachia_rename_lit
-			prestige = 2
 			707 = { change_province_name = "Suwalken" }
-			3381 = { change_province_name = "Lipsk" }
+			3381 = { change_province_name = "Metenburg" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	lit_poldachia_rename_russian = {
 		picture = gtfo
 		potential = {
 			is_culture_group = east_slavic
-			owns = 719 #Bialystok
+			owns = 707 #Suwalki
+			owns = 3381 #Augustov
 			NOT = { has_global_flag = lit_poldachia_rename_russian }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = lit_poldachia_rename_german
 			clr_global_flag = lit_poldachia_rename_polish
 			set_global_flag = lit_poldachia_rename_russian
 			clr_global_flag = lit_poldachia_rename_lit
-			prestige = 2
 			707 = { change_province_name = "Suwalki" }
 			3381 = { change_province_name = "Lipsk" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Lesser Poland ##
+
 	west_galicia_rename_polish = {
 		picture = gtfo
 		potential = {
 			OR = {
-				primary_culture = polish
+				AND = {
+					primary_culture = polish
+					is_vassal = no
+				}
 				AND = {
 					tag = DNB
 					accepted_culture = polish
@@ -342,18 +355,16 @@ political_decisions = {
 			owns = 716
 			NOT = { has_global_flag = west_galicia_rename_polish }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = west_galicia_rename_polish
 			clr_global_flag = west_galicia_rename_german
 			clr_global_flag = west_galicia_rename_russian
-			prestige = 2
 			711 = {
 				change_province_name = "Siedlce"
 				state_scope = { change_region_name = "Malopolska" }
@@ -362,32 +373,45 @@ political_decisions = {
 			715 = { change_province_name = "Lublin" }
 			716 = { change_province_name = "Kielce" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	west_galicia_rename_german = {
 		picture = gtfo
 		potential = {
 			is_culture_group = germanic
-			NOT = { tag = DNB }
-			owns = 711
-			owns = 713
-			owns = 715
-			owns = 716
+			NOT = {
+				AND = {
+					tag = DNB
+					accepted_culture = polish
+				}
+			}
+			OR = {
+				AND = {
+					owns = 711
+					owns = 713
+					owns = 715
+					owns = 716
+				}
+				711 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
 			NOT = { has_global_flag = west_galicia_rename_german }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			set_global_flag = west_galicia_rename_german
 			clr_global_flag = west_galicia_rename_polish
 			clr_global_flag = west_galicia_rename_russian
-			prestige = 2
 			711 = {
 				change_province_name = "Siedlce"
 				state_scope = { change_region_name = "Kleinpolen" }
@@ -396,16 +420,14 @@ political_decisions = {
 			716 = { change_province_name = "Kielce" }
 			713 = { change_province_name = "Radenau" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	west_galicia_rename_russian = {
 		picture = gtfo
 		potential = {
-			OR = {
-				primary_culture = russian
-				primary_culture = ukrainian
-			}
+			is_culture_group = east_slavic
 			owns = 711
 			owns = 713
 			owns = 715
@@ -413,19 +435,18 @@ political_decisions = {
 			NOT = {
 				has_global_flag = west_galicia_rename_russian
 			}
+			is_vassal = no
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
-		
+
 		effect = {
 			clr_global_flag = west_galicia_rename_german
 			clr_global_flag = west_galicia_rename_polish
 			set_global_flag = west_galicia_rename_russian
-			prestige = 2
 			711 = {
 				change_province_name = "Sedlets"
 				state_scope = { change_region_name = "Ljublin" }
@@ -434,11 +455,12 @@ political_decisions = {
 			715 = { change_province_name = "Ljublin" }
 			716 = { change_province_name = "Keljce" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
 
 ## Bessarabia ##
+
 	bessarabia_rename_rom = {
 		picture = gtfo
 		potential = {
@@ -447,52 +469,57 @@ political_decisions = {
 			owns = 677
 			owns = 673
 			NOT = { has_global_flag = bessarabia_rename_rom }
+			OR = {
+				tag = ROM
+				is_vassal = no
+			}
 		}
 
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
 			set_global_flag = bessarabia_rename_rom
-			clr_global_flag = bessarabia_rename_aus
-			676 = { change_province_name = "Chisinau"  
+			clr_global_flag = bessarabia_rename_rus
+			clr_global_flag = bessarabia_rename_tur
+			676 = {
+				change_province_name = "Chisinau"
 					state_scope = {
-					change_region_name = "Basarabia"}
-							}
+					change_region_name = "Basarabia"
+				}
+			}
 			677 = { change_province_name = "Cetatea Alba" }
 			678 = { change_province_name = "Ismail" }
 			673 = { change_province_name = "Cahul" }
 			3279 = { change_province_name = "Chelmenti" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	bessarabia_rename_rus = {
 		picture = gtfo
 		potential = {
-			OR = {
-				primary_culture = russian
-				primary_culture = ukrainian
-			}
+			is_culture_group = east_slavic
 			owns = 676
 			owns = 677
 			owns = 673
 			NOT = { has_global_flag = bessarabia_rename_rus }
+			is_vassal = no
 		}
 
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
 			set_global_flag = bessarabia_rename_rus
 			clr_global_flag = bessarabia_rename_rom
-			676 = { change_province_name = "Kishinyov" 
+			clr_global_flag = bessarabia_rename_tur
+			676 = { change_province_name = "Kishinyov"
 					state_scope = {
 					change_region_name = "Bessarabiya"}
 							}
@@ -501,243 +528,265 @@ political_decisions = {
 			673 = { change_province_name = "Kagul" }
 			3279 = { change_province_name = "Kelmentsi" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
-	# german_rename_bessarabien = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 678
-			# owns = 677
-			# owns = 673
-			# owns = 676
-			# owns = 3279
-			# NOT = { has_global_flag = german_rename_bessarabien }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_bessarabien
-			# 676 = { 
-				# change_province_name = "Kischinau" 
-				# state_scope = { change_region_name = "Bessarabien" }
-			# }
-			# 3279 = { change_province_name = "Chelmentz" }
-			# 673 = { change_province_name = "Katz" }
-			# 677 = { change_province_name = "Bohlrad" }
-			# 678 = { change_province_name = "Ismailburg" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# degermanize_bessarabien = {
-		# picture = gtfo
-		# potential = {
-			# NOT = { is_culture_group = germanic }
-			# owns = 678
-			# owns = 677
-			# owns = 673
-			# owns = 676
-			# owns = 3279
-			# has_global_flag = german_rename_bessarabien
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_bessarabien
-			# 676 = { 
-				# change_province_name = "Kishinyou" 
-				# state_scope = { change_region_name = "Bessarabiya" }
-			# }
-			# 3279 = { change_province_name = "Kelemtsi" }
-			# 673 = { change_province_name = "Kagul" }
-			# 677 = { change_province_name = "Belgorod" }
-			# 678 = { change_province_name = "Izmail" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
+	bessarabia_rename_tur = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 676
+			owns = 677
+			owns = 673
+			NOT = { has_global_flag = bessarabia_rename_tur }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = bessarabia_rename_tur
+			clr_global_flag = bessarabia_rename_rom
+			clr_global_flag = bessarabia_rename_rus
+			676 = {
+				change_province_name = "Kisinev"
+				state_scope = {	change_region_name = "Besarabya" }
+			}
+			677 = { change_province_name = "Akkerman" }
+			678 = { change_province_name = "Ismailiye" }
+			673 = { change_province_name = "Kartal Ovasi" }
+			3279 = { change_province_name = "Kelmentsi" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	german_rename_bessarabien = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 677
+					owns = 673
+					owns = 676
+				}
+				676 = {
+					owner = {
+						OR = {
+							tag = ROM
+							vassal_of = THIS
+						}
+					}
+				}
+			}
+
+			NOT = { has_global_flag = german_rename_bessarabien }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_bessarabien
+			clr_global_flag = bessarabia_rename_tur
+			clr_global_flag = bessarabia_rename_rom
+			clr_global_flag = bessarabia_rename_rus
+			676 = {
+				change_province_name = "Kischinau"
+				state_scope = { change_region_name = "Bessarabien" }
+			}
+			3279 = { change_province_name = "Chelmentz" }
+			673 = { change_province_name = "Katz" }
+			677 = { change_province_name = "Bohlrad" }
+			678 = { change_province_name = "Ismailburg" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
 
 ## Finland ##
+
 	finland_rename_swe = {
 		picture = gtfo
 		potential = {
-				owns = 343
-				owns = 336
-				owns = 345
-				primary_culture = swedish
-				NOT = { tag = SCA }
+			owns = 343
+			owns = 336
+			owns = 345
+			primary_culture = swedish
+			NOT = { tag = SCA }
 			NOT = { has_global_flag = finland_rename_swe }
 		}
 
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
-				##Northern Finland##
-				336 = {
-					change_province_name = "Uleåborg"
-					state_scope = { change_region_name = "Österbotten" }
-				}
-				346 = { change_province_name = "Vasa" }
-				338 = { change_province_name = "Torneå" }
-				3379 = { change_province_name = "Kuolajärvi" }
+			##Northern Finland##
+			336 = {
+				change_province_name = "Uleåborg"
+				state_scope = { change_region_name = "Österbotten" }
+			}
+			346 = { change_province_name = "Vasa" }
+			338 = { change_province_name = "Torneå" }
+			3379 = { change_province_name = "Kuolajärvi" }
 
-				##Western Finland##
-				343 = {
-					change_province_name = "Helsingfors"
-					state_scope = { change_region_name = "Egentliga Finland" }
-				}
-				344 = { change_province_name = "Tavastehus" }
-				345 = { change_province_name = "Åbo" }
-				348 = { change_province_name = "Landskapet Åland" }
+			##Western Finland##
+			343 = {
+				change_province_name = "Helsingfors"
+				state_scope = { change_region_name = "Egentliga Finland" }
+			}
+			344 = { change_province_name = "Tavastehus" }
+			345 = { change_province_name = "Åbo" }
+			348 = { change_province_name = "Landskapet Åland" }
 
-				##Eastern Finland##
-				339 = { change_province_name = "Viborg" }
-				340 = { change_province_name = "Kotka" }
-				341 = { change_province_name = "S:t Michel"
-						state_scope = { change_region_name = "Nyland" }
-					}
-				337 = { change_province_name = "Kajana" }
-				342 = { change_province_name = "Kuopio" }
+			##Eastern Finland##
+			339 = { change_province_name = "Viborg" }
+			340 = { change_province_name = "Kotka" }
+			341 = { change_province_name = "S:t Michel"
+					state_scope = { change_region_name = "Nyland" }
+			}
+			337 = { change_province_name = "Kajana" }
+			342 = { change_province_name = "Kuopio" }
 			set_global_flag = finland_rename_swe
 			clr_global_flag = finland_rename_fin
 			clr_global_flag = finland_rename_rus
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	finland_rename_fin = {
 		picture = gtfo
 		potential = {
-				owns = 343
-				owns = 336
-				owns = 345
-
-				OR = {
-					primary_culture = finnish
-					tag = SCA }
+			owns = 343
+			owns = 336
+			owns = 345
+			OR = {
+				primary_culture = finnish
+				tag = SCA
+			}
 			NOT = { has_global_flag = finland_rename_fin }
 		}
 
 		allow = {
 			war = no
 			state_n_government = 1
-
 			is_vassal = no
 		}
 
 		effect = {
-				##Northern Finland##
-				336 = {
-					change_province_name = "Oulu"
-					state_scope = { change_region_name = "Pohjanmaa" }
-				}
-				346 = { change_province_name = "Vaasa" }
-				338 = { change_province_name = "Tornio" }
-				3379 = { change_province_name = "Kuolajärvi" }
+			##Northern Finland##
+			336 = {
+				change_province_name = "Oulu"
+				state_scope = { change_region_name = "Pohjanmaa" }
+			}
+			346 = { change_province_name = "Vaasa" }
+			338 = { change_province_name = "Tornio" }
+			3379 = { change_province_name = "Kuolajärvi" }
 
-				##Western Finland##
-				343 = {
-					change_province_name = "Helsinki"
-					state_scope = { change_region_name = "Varsinais-Suomi" }
-				}
-				344 = { change_province_name = "Hämeenlinna" }
-				345 = { change_province_name = "Turku" }
-				348 = { change_province_name = "Ahvenanmaa" }
+			##Western Finland##
+			343 = {
+				change_province_name = "Helsinki"
+				state_scope = { change_region_name = "Varsinais-Suomi" }
+			}
+			344 = { change_province_name = "Hämeenlinna" }
+			345 = { change_province_name = "Turku" }
+			348 = { change_province_name = "Ahvenanmaa" }
 
-				##Eastern Finland##
-				339 = { change_province_name = "Viipuri" }
-				340 = { change_province_name = "Kotka" }
-				341 = { change_province_name = "Mikkeli"
-						state_scope = { change_region_name = "Uusimaa" }
-					}
-				337 = { change_province_name = "Kajaani" }
-				342 = { change_province_name = "Kuopio" }
+			##Eastern Finland##
+			339 = { change_province_name = "Viipuri" }
+			340 = { change_province_name = "Kotka" }
+			341 = { change_province_name = "Mikkeli"
+					state_scope = { change_region_name = "Uusimaa" }
+				}
+			337 = { change_province_name = "Kajaani" }
+			342 = { change_province_name = "Kuopio" }
 
 			set_global_flag = finland_rename_fin
 			clr_global_flag = finland_rename_swe
 			clr_global_flag = finland_rename_rus
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	finland_rename_rus = {
 		picture = gtfo
 		potential = {
-				primary_culture = russian
-				OR = {
-					AND = { 
-						owns = 343
-						owns = 336
-						owns = 345
-						}
-					AND = {
-						is_our_vassal = FIN
-						has_country_flag = finland_russification
-						}
-					}
-				NOT = { has_global_flag = finland_rename_rus }
+			is_culture_group = east_slavic
+			OR = {
+				AND = {
+					owns = 343
+					owns = 336
+					owns = 345
+				}
+				AND = {
+					is_our_vassal = FIN
+					has_country_flag = finland_russification
+				}
+			}
+			NOT = { has_global_flag = finland_rename_rus }
 		}
 
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
-				##Northern Finland##
-				336 = {
-					change_province_name = "Oulu"
-					state_scope = { change_region_name = "Severnaya Finlandia" }
-				}
-				346 = { change_province_name = "Nikolaistad" }
-				338 = { change_province_name = "Torneo" }
-				3379 = { change_province_name = "Kuoloyarvi" }
+			##Northern Finland##
+			336 = {
+				change_province_name = "Oulu"
+				state_scope = { change_region_name = "Severnaya Finlandia" }
+			}
+			346 = { change_province_name = "Nikolaistad" }
+			338 = { change_province_name = "Torneo" }
+			3379 = { change_province_name = "Kuoloyarvi" }
 
-				##Western Finland##
-				343 = {
-					change_province_name = "Gelsingfors"
-					state_scope = { change_region_name = "Zapadnaya Finlandia" }
-				}
-				344 = { change_province_name = "Tavastgus" }
-				345 = { change_province_name = "Abo" }
-				348 = { change_province_name = "Oland" }
+			##Western Finland##
+			343 = {
+				change_province_name = "Gelsingfors"
+				state_scope = { change_region_name = "Zapadnaya Finlandia" }
+			}
+			344 = { change_province_name = "Tavastgus" }
+			345 = { change_province_name = "Abo" }
+			348 = { change_province_name = "Oland" }
 
-				##Eastern Finland##
-				339 = { change_province_name = "Wyborg" }
-				340 = { change_province_name = "Kotka" }
-				341 = { change_province_name = "St. Michel"
-						state_scope = { change_region_name = "Vostochnaya Finlandia" }
-					}
-				337 = { change_province_name = "Kajana" }
-				342 = { change_province_name = "Kuopio" }
+			##Eastern Finland##
+			339 = { change_province_name = "Wyborg" }
+			340 = { change_province_name = "Kotka" }
+			341 = { change_province_name = "St. Michel"
+					state_scope = { change_region_name = "Vostochnaya Finlandia" }
+				}
+			337 = { change_province_name = "Kajana" }
+			342 = { change_province_name = "Kuopio" }
 
 			set_global_flag = finland_rename_rus
 			clr_global_flag = finland_rename_fin
 			clr_global_flag = finland_rename_swe
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Karelia ##
+
 	karelia_rename_fin = {
 		picture = gtfo
 		potential = {
 			OR = {
-			primary_culture = finnish
-			primary_culture = swedish
+				primary_culture = finnish
+				primary_culture = swedish
+				tag = SCA
 			}
 			owns = 982
 			owns = 995
@@ -748,13 +797,12 @@ political_decisions = {
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
 			set_global_flag = karelia_rename_fin
 			clr_global_flag = karelia_rename_rus
-			982 = { change_province_name = "Petsamo" 
+			982 = { change_province_name = "Petsamo"
 					state_scope = {
 					change_region_name = "Karjala"}
 							}
@@ -763,13 +811,14 @@ political_decisions = {
 			984 = { change_province_name = "Kostamus" }
 			995 = { change_province_name = "Petroskoi " }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	karelia_rename_rus = {
 		picture = gtfo
 		potential = {
-			primary_culture = russian
+			is_culture_group = east_slavic
 			owns = 982
 			owns = 995
 			owns = 2587
@@ -779,13 +828,12 @@ political_decisions = {
 		allow = {
 			war = no
 			state_n_government = 1
-
 		}
 
 		effect = {
 			set_global_flag = karelia_rename_rus
 			clr_global_flag = karelia_rename_fin
-			982 = { change_province_name = "Petschenga" 
+			982 = { change_province_name = "Petschenga"
 					state_scope = {
 					change_region_name = "Kareliya"}
 							}
@@ -794,10 +842,12 @@ political_decisions = {
 			984 = { change_province_name = "Kostomuksha" }
 			995 = { change_province_name = "Petrosavodsk" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Lithuania ##
+
 	lithuania_rename = {
 		picture = gtfo
 		potential = {
@@ -812,7 +862,7 @@ political_decisions = {
 					}
 				}
 				AND = {
-					OR = { 
+					OR = {
 						primary_culture = lithuanian
 						is_culture_group = baltic
 						tag = PLC
@@ -842,13 +892,13 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 
 		}
-		
+
 		effect = {
 			###German###
 			random_owned = {
@@ -858,24 +908,24 @@ political_decisions = {
 						is_culture_group = germanic
 					}
 				}
-				361 = { 
-					change_province_name = "Kauen" 
+				361 = {
+					change_province_name = "Kauen"
 					state_scope = {
 						change_region_name = "Litauen"
 					}
-				}		
-				362 = { change_province_name = "Mariampol" }	
+				}
+				362 = { change_province_name = "Mariampol" }
 				363 = { change_province_name = "Ponewiesch" }
-				364 = { change_province_name = "Schaulen" }		
-				365 = { change_province_name = "Polangen" }	
-				owner = { 
-					set_global_flag = german_renamed_lithuania 
-					clr_global_flag = lithuanian_renamed_lithuania 
-					clr_global_flag = russian_renamed_lithuania 
-					clr_global_flag = polish_renamed_lithuania 
+				364 = { change_province_name = "Schaulen" }
+				365 = { change_province_name = "Polangen" }
+				owner = {
+					set_global_flag = german_renamed_lithuania
+					clr_global_flag = lithuanian_renamed_lithuania
+					clr_global_flag = russian_renamed_lithuania
+					clr_global_flag = polish_renamed_lithuania
 				}
 			}
-			
+
 			###German - Vilnius###
 			random_owned = {
 				limit = {
@@ -885,14 +935,14 @@ political_decisions = {
 					}
 				}
 				360 = { change_province_name = "Wilna" }
-				owner = { 
+				owner = {
 					set_global_flag = german_renamed_vilnius
 					clr_global_flag = lithuanian_renamed_vilnius
 					clr_global_flag = russian_renamed_vilnius
 					clr_global_flag = polish_renamed_vilnius
 				}
 			}
-			
+
 			###German - Pinsk###
 			random_owned = {
 				limit = {
@@ -903,50 +953,50 @@ political_decisions = {
 				}
 				938 = { change_province_name = "Lida" }
 				936 = { change_province_name = "Garten" }
-				owner = { 
+				owner = {
 					set_global_flag = german_renamed_lithuania_pinsk
 					clr_global_flag = lithuanian_renamed_lithuania_pinsk
 					clr_global_flag = russian_renamed_lithuania_pinsk
 					clr_global_flag = polish_renamed_lithuania_pinsk
 				}
 			}
-			
+
 			###Lithuanian###
 			random_owned = {
 				limit = {
 					province_id = 361
 					owner = {
-						OR = { 
+						OR = {
 							primary_culture = lithuanian
 							is_culture_group = baltic
 							tag = PLC
 						}
 					}
 				}
-				361 = { 
-					change_province_name = "Kaunas" 
+				361 = {
+					change_province_name = "Kaunas"
 					state_scope = {
 						change_region_name = "Lietuvos"
 					}
-				}		
-				362 = { change_province_name = "Marijampole" }	
+				}
+				362 = { change_province_name = "Marijampole" }
 				363 = { change_province_name = "Panevežys" }
-				364 = { change_province_name = "Šiauliai" }		
-				365 = { change_province_name = "Palanga" }		
-				owner = { 
+				364 = { change_province_name = "Šiauliai" }
+				365 = { change_province_name = "Palanga" }
+				owner = {
 					set_global_flag = lithuanian_renamed_lithuania
 					clr_global_flag = german_renamed_lithuania
-					clr_global_flag = russian_renamed_lithuania 
+					clr_global_flag = russian_renamed_lithuania
 					clr_global_flag = polish_renamed_lithuania
 				}
 			}
-			
+
 			###Lithuanian - Vilnius###
 			random_owned = {
 				limit = {
 					province_id = 360
 					owner = {
-						OR = { 
+						OR = {
 							primary_culture = lithuanian
 							is_culture_group = baltic
 							tag = PLC
@@ -954,20 +1004,20 @@ political_decisions = {
 					}
 				}
 				360 = { change_province_name = "Vilnius" }
-				owner = { 
+				owner = {
 					set_global_flag = lithuanian_renamed_vilnius
 					clr_global_flag = german_renamed_vilnius
 					clr_global_flag = russian_renamed_vilnius
 					clr_global_flag = polish_renamed_vilnius
 				}
 			}
-			
+
 			###Lithuanian - Pinsk###
 			random_owned = {
 				limit = {
 					province_id = 938
 					owner = {
-						OR = { 
+						OR = {
 							primary_culture = lithuanian
 							is_culture_group = baltic
 							tag = PLC
@@ -976,14 +1026,14 @@ political_decisions = {
 				}
 				938 = { change_province_name = "Lyda" }
 				936 = { change_province_name = "Gardinas" }
-				owner = { 
+				owner = {
 					set_global_flag = lithuanian_renamed_lithuania_pinsk
 					clr_global_flag = german_renamed_lithuania_pinsk
-					clr_global_flag = russian_renamed_lithuania_pinsk 
+					clr_global_flag = russian_renamed_lithuania_pinsk
 					clr_global_flag = polish_renamed_lithuania_pinsk
 				}
 			}
-			
+
 			###Russian###
 			random_owned = {
 				limit = {
@@ -992,24 +1042,24 @@ political_decisions = {
 						is_culture_group = east_slavic
 					}
 				}
-				361 = { 
+				361 = {
 					change_province_name = "Kovno"
 					state_scope = {
 						change_region_name = "Litvá"
 					}
-				}		
-				362 = { change_province_name = "Mariyampole" }	
+				}
+				362 = { change_province_name = "Mariyampole" }
 				363 = { change_province_name = "Ponevezh" }
-				364 = { change_province_name = "Shyaulyai" }		
-				365 = { change_province_name = "Palanga" }		
-				owner = { 
+				364 = { change_province_name = "Shyaulyai" }
+				365 = { change_province_name = "Palanga" }
+				owner = {
 					set_global_flag = russian_renamed_lithuania
 					clr_global_flag = german_renamed_lithuania
 					clr_global_flag = lithuanian_renamed_lithuania
 					clr_global_flag = polish_renamed_lithuania
 				}
 			}
-			
+
 			###Russian - Vilnius###
 			random_owned = {
 				limit = {
@@ -1019,14 +1069,14 @@ political_decisions = {
 					}
 				}
 				360 = { change_province_name = "Vilna" }
-				owner = { 
+				owner = {
 					set_global_flag = russian_renamed_vilnius
 					clr_global_flag = german_renamed_vilnius
 					clr_global_flag = lithuanian_renamed_vilnius
 					clr_global_flag = polish_renamed_vilnius
 				}
 			}
-			
+
 			###Russian - Pinsk###
 			random_owned = {
 				limit = {
@@ -1037,14 +1087,14 @@ political_decisions = {
 				}
 				938 = { change_province_name = "Lida" }
 				936 = { change_province_name = "Grodno" }
-				owner = { 
+				owner = {
 					set_global_flag = russian_renamed_lithuania_pinsk
 					clr_global_flag = lithuanian_renamed_lithuania_pinsk
 					clr_global_flag = german_renamed_lithuania_pinsk
 					clr_global_flag = polish_renamed_lithuania_pinsk
 				}
 			}
-			
+
 			###Polish###
 			random_owned = {
 				limit = {
@@ -1054,24 +1104,24 @@ political_decisions = {
 						NOT = { tag = PLC }
 					}
 				}
-				361 = { 
-					change_province_name = "Kowno" 
+				361 = {
+					change_province_name = "Kowno"
 					state_scope = {
 						change_region_name = "Litwa"
 					}
-				}		
-				362 = { change_province_name = "Mariampol" }	
+				}
+				362 = { change_province_name = "Mariampol" }
 				363 = { change_province_name = "Poniewiez" }
-				364 = { change_province_name = "Szawle" }		
-				365 = { change_province_name = "Polaga" }		
-				owner = { 
+				364 = { change_province_name = "Szawle" }
+				365 = { change_province_name = "Polaga" }
+				owner = {
 					set_global_flag = polish_renamed_lithuania
 					clr_global_flag = german_renamed_lithuania
 					clr_global_flag = lithuanian_renamed_lithuania
 					clr_global_flag = russian_renamed_lithuania
 				}
 			}
-			
+
 			###Polish - Vilnius###
 			random_owned = {
 				limit = {
@@ -1082,14 +1132,14 @@ political_decisions = {
 					}
 				}
 				360 = { change_province_name = "Wilno" }
-				owner = { 
+				owner = {
 					set_global_flag = polish_renamed_vilnius
 					clr_global_flag = german_renamed_vilnius
 					clr_global_flag = lithuanian_renamed_vilnius
 					clr_global_flag = russian_renamed_vilnius
 				}
 			}
-			
+
 			###Polish - Pinsk###
 			random_owned = {
 				limit = {
@@ -1101,7 +1151,7 @@ political_decisions = {
 				}
 				938 = { change_province_name = "Lida" }
 				936 = { change_province_name = "Grodno" }
-				owner = { 
+				owner = {
 					set_global_flag = polish_renamed_lithuania_pinsk
 					clr_global_flag = lithuanian_renamed_lithuania_pinsk
 					clr_global_flag = german_renamed_lithuania_pinsk
@@ -1111,8 +1161,9 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 ## Latvia ##
+
 	latvia_rename = {
 		picture = gtfo
 		potential = {
@@ -1122,11 +1173,11 @@ political_decisions = {
 					OR = {
 						AND = { owns = 356 NOT = { has_global_flag = german_renamed_daugavpils } }
 						AND = { owns = 354 NOT = { has_global_flag = german_renamed_lativa } }
-						
+
 					}
 				}
 				AND = {
-					OR = { 
+					OR = {
 						primary_culture = latvian
 						is_culture_group = baltic
 					}
@@ -1151,13 +1202,13 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 
 		}
-		
+
 		effect = {
 			###German###
 			random_owned = {
@@ -1168,10 +1219,10 @@ political_decisions = {
 					}
 				}
 				356 = { change_province_name = "Dünaburg"  }
-				owner = { 
-					set_global_flag = german_renamed_daugavpils 
+				owner = {
+					set_global_flag = german_renamed_daugavpils
 					clr_global_flag = latvian_renamed_daugavpils
-					clr_global_flag = polish_renamed_daugavpils 
+					clr_global_flag = polish_renamed_daugavpils
 					clr_global_flag = russian_renamed_daugavpils
 				}
 			}
@@ -1190,15 +1241,15 @@ political_decisions = {
 					}
 				}
 				358 = { change_province_name = "Windau" }
-				359 = { change_province_name = "Libau" }	
-				owner = { 
-					set_global_flag = german_renamed_lativa 
-					clr_global_flag = latvian_renamed_lativa 
-					clr_global_flag = russian_renamed_lativa 
-					clr_global_flag = polish_renamed_lativa 
+				359 = { change_province_name = "Libau" }
+				owner = {
+					set_global_flag = german_renamed_lativa
+					clr_global_flag = latvian_renamed_lativa
+					clr_global_flag = russian_renamed_lativa
+					clr_global_flag = polish_renamed_lativa
 				}
 			}
-			
+
 			###Polish###
 			random_owned = {
 				limit = {
@@ -1208,8 +1259,8 @@ political_decisions = {
 					}
 				}
 				356 = { change_province_name = "Dyneburg"  }
-				owner = { 
-					set_global_flag = polish_renamed_daugavpils 
+				owner = {
+					set_global_flag = polish_renamed_daugavpils
 					clr_global_flag = latvian_renamed_daugavpils
 					clr_global_flag = russian_renamed_daugavpils
 					clr_global_flag = german_renamed_daugavpils
@@ -1230,30 +1281,30 @@ political_decisions = {
 					}
 				}
 				358 = { change_province_name = "Windawa" }
-				359 = { change_province_name = "Lipawa" }	
-				owner = { 
-					set_global_flag = polish_renamed_lativa 
-					clr_global_flag = latvian_renamed_lativa 
-					clr_global_flag = russian_renamed_lativa 
+				359 = { change_province_name = "Lipawa" }
+				owner = {
+					set_global_flag = polish_renamed_lativa
+					clr_global_flag = latvian_renamed_lativa
+					clr_global_flag = russian_renamed_lativa
 					clr_global_flag = german_renamed_lativa
 				}
 			}
-			
+
 			###Latvian###
 			random_owned = {
 				limit = {
 					province_id = 356
 					owner = {
-						OR = { 
+						OR = {
 							primary_culture = latvian
 							is_culture_group = baltic
 						}
 					}
 				}
 				356 = { change_province_name = "Daugavpils"  }
-				owner = { 
+				owner = {
 					set_global_flag = latvian_renamed_daugavpils
-					clr_global_flag = polish_renamed_daugavpils 
+					clr_global_flag = polish_renamed_daugavpils
 					clr_global_flag = german_renamed_daugavpils
 					clr_global_flag = russian_renamed_daugavpils
 				}
@@ -1273,15 +1324,15 @@ political_decisions = {
 					}
 				}
 				358 = { change_province_name = "Ventspils" }
-				359 = { change_province_name = "Liepaja" }	
-				owner = { 
+				359 = { change_province_name = "Liepaja" }
+				owner = {
 					set_global_flag = latvian_renamed_lativa
 					clr_global_flag = german_renamed_lativa
-					clr_global_flag = russian_renamed_lativa 
+					clr_global_flag = russian_renamed_lativa
 					clr_global_flag = polish_renamed_lativa
 				}
 			}
-			
+
 			###Russian###
 			random_owned = {
 				limit = {
@@ -1291,9 +1342,9 @@ political_decisions = {
 					}
 				}
 				356 = { change_province_name = "Daugavpils"  }
-				owner = { 
+				owner = {
 					set_global_flag = russian_renamed_daugavpils
-					clr_global_flag = polish_renamed_daugavpils 
+					clr_global_flag = polish_renamed_daugavpils
 					clr_global_flag = german_renamed_daugavpils
 					clr_global_flag = latvian_renamed_daugavpils
 				}
@@ -1313,21 +1364,22 @@ political_decisions = {
 					}
 				}
 				358 = { change_province_name = "Vindava" }
-				359 = { change_province_name = "Liepaja" }	
+				359 = { change_province_name = "Liepaja" }
 				owner = {
 					set_global_flag = russian_renamed_lativa
-					clr_global_flag = latvian_renamed_lativa 
+					clr_global_flag = latvian_renamed_lativa
 					clr_global_flag = german_renamed_lativa
 					clr_global_flag = polish_renamed_lativa
 				}
 			}
 		}
-		
-		
+
+
 		ai_will_do = { factor = 1 }
 	}
 
-## Estonia ##	
+## Estonia ##
+
 	estonia_rename = {
 		picture = gtfo
 		potential = {
@@ -1358,13 +1410,13 @@ political_decisions = {
 
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 
 		}
-		
+
 		effect = {
 			###German###
 			random_owned = {
@@ -1384,11 +1436,11 @@ political_decisions = {
 				351 = { change_province_name = "Pernau" }
 				352 = { change_province_name = "Dorpat" }
 				353 = { change_province_name = "Ösel" }
-				owner = { 
-					set_global_flag = german_renamed_estonia 
-					clr_global_flag = estonian_renamed_estonia 
+				owner = {
+					set_global_flag = german_renamed_estonia
+					clr_global_flag = estonian_renamed_estonia
 					clr_global_flag = russian_renamed_estonia
-					clr_global_flag = swedish_renamed_estonia 					
+					clr_global_flag = swedish_renamed_estonia
 				}
 			}
 
@@ -1414,20 +1466,20 @@ political_decisions = {
 				351 = { change_province_name = "Pernau" }
 				352 = { change_province_name = "Dorpat" }
 				353 = { change_province_name = "Örnborg" }
-				owner = { 
-					set_global_flag = swedish_renamed_estonia 
-					clr_global_flag = estonian_renamed_estonia 
-					clr_global_flag = russian_renamed_estonia 
+				owner = {
+					set_global_flag = swedish_renamed_estonia
+					clr_global_flag = estonian_renamed_estonia
+					clr_global_flag = russian_renamed_estonia
 					clr_global_flag = german_renamed_estonia
 				}
 			}
-			
+
 			###Estonian###
 			random_owned = {
 				limit = {
 					province_id = 349
 					owner = {
-						OR = { 
+						OR = {
 							primary_culture = estonian
 							is_culture_group = baltic
 							AND = {
@@ -1447,14 +1499,14 @@ political_decisions = {
 				351 = { change_province_name = "Parnu" }
 				352 = { change_province_name = "Tartu" }
 				353 = { change_province_name = "Saaremaa" }
-				owner = { 
+				owner = {
 					set_global_flag = estonian_renamed_estonia
 					clr_global_flag = german_renamed_estonia
 					clr_global_flag = russian_renamed_estonia
-					clr_global_flag = swedish_renamed_estonia 
+					clr_global_flag = swedish_renamed_estonia
 				}
 			}
-			
+
 			###Russian###
 			random_owned = {
 				limit = {
@@ -1475,9 +1527,9 @@ political_decisions = {
 				353 = { change_province_name = "Ostrov Saami" }
 				owner = {
 					set_global_flag = russian_renamed_estonia
-					clr_global_flag = estonian_renamed_estonia 
+					clr_global_flag = estonian_renamed_estonia
 					clr_global_flag = german_renamed_estonia
-					clr_global_flag = swedish_renamed_estonia 
+					clr_global_flag = swedish_renamed_estonia
 					}
 				}
 			}
@@ -1486,7 +1538,8 @@ political_decisions = {
 
 ## Vladivostok (see RUS.txt) ##
 
-## St. Petersburg ##	
+## St. Petersburg ##
+
 	petrograd_renaming_act = {
 		picture = petrograd_city
 		potential = {
@@ -1502,11 +1555,11 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			mass_politics = 1
 		}
-		
+
 		effect = {
 			set_country_flag = peters_city_renamed
 			994 = { change_province_name = "Petrograd" }
@@ -1519,23 +1572,56 @@ political_decisions = {
 		}
 
 		ai_will_do = {
-			factor = 1 
-				modifier = {
-					factor = 0
-					NOT = { war_exhaustion = 20 }
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { war_exhaustion = 20 }
+			}
+		}
+	}
+
+	petrograd_renaming_act2 = {
+		picture = petrograd_city
+		potential = {
+			is_culture_group = germanic
+			994 = {
+				owner = {
+					primary_culture = russian
+					has_country_flag = peters_city_renamed
+					NOT = { has_country_flag = names_of_the_revolution }
+					vassal_of = THIS
 				}
 			}
 		}
 
-## Soviet Names - Need to be Doublechecked ##
+		allow = {
+			mass_politics = 1
+		}
+
+		effect = {
+			clr_country_flag = peters_city_renamed
+			994 = { change_province_name = "Sankt-Peterburg" }
+			prestige = 10
+			any_pop = {
+				limit = { is_primary_culture = yes }
+				dominant_issue = { factor = 0.1 value = jingoism }
+				militancy = -1
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Soviet Names ##
+
 	names_of_the_revolution = {
 		picture = names_of_the_rev
 		potential = {
-			primary_culture = russian
+			is_culture_group = east_slavic
 			government = proletarian_dictatorship
 			NOT = { has_country_flag = names_of_the_revolution }
-			owns = 996
 			owns = 994
+			owns = 996
 			owns = 998
 			owns = 1020
 			owns = 1028
@@ -1543,23 +1629,15 @@ political_decisions = {
 			owns = 1039
 			owns = 1058
 		}
-		
+
 		allow = {
-			owns = 996
-			owns = 994
-			owns = 998
-			owns = 1020
-			owns = 1028
-			owns = 1034
-			owns = 1039
-			owns = 1058
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_country_flag = names_of_the_revolution
-			996 = { change_province_name = "Petrogradsky" }
 			994 = { change_province_name = "Leningrad" }
+			996 = { change_province_name = "Petrogradsky" }
 			998 = { change_province_name = "Kalinin" }
 			998 = { state_scope = { change_region_name = "Kalinin Oblast" } }
 			1020 = { change_province_name = "Gorky" }
@@ -1567,18 +1645,26 @@ political_decisions = {
 			1034 = { change_province_name = "Kuybyshev" }
 			1039 = { change_province_name = "Stalingrad" }
 			1058 = { change_province_name = "Sverdlovsk" }
+			any_owned = {
+				limit = {
+					province_id = 695
+				}
+				change_province_name = "Kaliningrad"
+				state_scope = { change_region_name = "Kaliningrad" }
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	remove_names_of_the_revolution = {
 		picture = names_of_the_rev
 		potential = {
-			primary_culture = russian
+			is_culture_group = east_slavic
 			NOT = { government = proletarian_dictatorship }
 			has_country_flag = names_of_the_revolution
-			owns = 996
 			owns = 994
+			owns = 996
 			owns = 998
 			owns = 1020
 			owns = 1028
@@ -1586,23 +1672,28 @@ political_decisions = {
 			owns = 1039
 			owns = 1058
 		}
-		
+
 		allow = {
-			owns = 996
-			owns = 994
-			owns = 998
-			owns = 1020
-			owns = 1028
-			owns = 1034
-			owns = 1039
-			owns = 1058
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_country_flag = names_of_the_revolution
+			any_owned = {
+				limit = {
+					province_id = 994
+					owner = { has_country_flag = peters_city_renamed }
+				}
+				change_province_name = "Petrograd"
+			}
+			any_owned = {
+				limit = {
+					province_id = 994
+					NOT = { has_country_flag = peters_city_renamed }
+				}
+				change_province_name = "Sankt-Peterburg"
+			}
 			996 = { change_province_name = "Luga" }
-			994 = { change_province_name = "Petrograd" }
 			998 = { change_province_name = "Tver" }
 			998 = { state_scope = { change_region_name = "Tver" } }
 			1020 = { change_province_name = "Nizhni Novgorod" }
@@ -1610,710 +1701,1487 @@ political_decisions = {
 			1034 = { change_province_name = "Samara" }
 			1039 = { change_province_name = "Tsaritsyn" }
 			1058 = { change_province_name = "Ekaterinburg" }
+			any_owned = {
+				limit = {
+					province_id = 695
+				}
+				change_province_name = "Korolevets"
+				state_scope = { change_region_name = "Vostochnaya Prussiya" }
 			}
-		ai_will_do = {
-			factor = 1
 		}
+
+		ai_will_do = { factor = 1 }
 	}
-	
+
 	names_of_the_revolution_ukraine = {
 		picture = names_of_the_rev
 		potential = {
-			primary_culture = russian
+			is_culture_group = east_slavic
 			government = proletarian_dictatorship
 			NOT = { has_global_flag = names_of_the_revolution_ukraine }
 			owns = 972
-			owns = 975
+			owns = 974
 			owns = 976
 			owns = 980
 		}
-		
+
 		allow = {
-			owns = 972
-			owns = 975
-			owns = 976
-			owns = 980
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = names_of_the_revolution_ukraine
 			972 = { change_province_name = "Sicheslav" }
-			975 = { change_province_name = "Stalino" }
+			974 = { change_province_name = "Stalino" }
 			976 = { change_province_name = "Zhdanov" }
 			980 = { change_province_name = "Voroshilovgrad" }
 		}
-		ai_will_do = {
-			factor = 1
-		}
+
+		ai_will_do = { factor = 1 }
 	}
-	
+
 	remove_names_of_the_revolution_ukraine = {
 		picture = names_of_the_rev
 		potential = {
+			is_culture_group = east_slavic
 			NOT = { government = proletarian_dictatorship }
 			has_global_flag = names_of_the_revolution_ukraine
 			owns = 972
-			owns = 975
+			owns = 974
 			owns = 976
 			owns = 980
 		}
-		
+
 		allow = {
-			owns = 972
-			owns = 975
-			owns = 976
-			owns = 980
 			state_n_government = 1
-			}
-		
+		}
+
 		effect = {
 			clr_global_flag = names_of_the_revolution_ukraine
-			975 = { change_province_name = "Yuzovka" }
+			972 = { change_province_name = "Yekaterinoslav" }
+			974 = { change_province_name = "Donetsk" }
 			976 = { change_province_name = "Mariupol" }
 			980 = { change_province_name = "Luhansk" }
-			}
-		ai_will_do = {
-			factor = 1
 		}
+
+		ai_will_do = { factor = 1 }
 	}
 
-## To be Cleaned Up Later ##
-	# polish_minsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 718
-			# owns = 941
-			# owns = 942
-			# NOT = { has_global_flag = polish_minsk }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_minsk
-			# set_global_flag = polish_minsk
-			# 718 = { 
-				# change_province_name = "Minsk" 
-				# state_scope = { change_region_name = "Minsk" }
-			# }
-			# 941 = { change_province_name = "Sluck" }
-			# 942 = { change_province_name = "Mozyrz" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+## Orsha ##
 
-	# polish_kyiv = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 955
-			# owns = 959
-			# owns = 960
-			# owns = 958
-			# NOT = { has_global_flag = polish_kyiv }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = polish_kyiv
-			# clr_global_flag = german_rename_kyiv
-			# 958 = { 
-				# change_province_name = "Kijów" 
-				# state_scope = { change_region_name = "Kijów" }
-			# }
-			# 960 = { change_province_name = "Zytomierz" }
-			# 959 = { change_province_name = "Korstów" }
-			# 955 = { change_province_name = "Chmielnicki" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+	polish_orsha = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 944
+			owns = 946
+			owns = 949
+			NOT = { has_global_flag = polish_orsha }
+		}
 
-	# polish_brêst = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 936
-			# owns = 937
-			# owns = 940
-			# NOT = { has_global_flag = polish_brêst }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = polish_brêst
-			# clr_global_flag = german_rename_brêst
-			# 937 = { 
-				# change_province_name = "Grodno" 
-				# state_scope = { change_region_name = "Brzesc" }
-			# }
-			# 936 = { change_province_name = "Pruzana" }
-			# 940 = { change_province_name = "Brzesc Litewski" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# polish_orsha = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 944
-			# owns = 946
-			# owns = 949
-			# NOT = { has_global_flag = polish_orsha }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = polish_orsha
-			# 944 = { 
-				# change_province_name = "Orsza" 
-				# state_scope = { change_region_name = "Orsza" }
-			# }
-			# 945 = { change_province_name = "Witebsk" }
-			# 946 = { change_province_name = "Lepel" }
-			# 948 = { change_province_name = "Moglew" }
-			# 949 = { change_province_name = "Gomel" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# russian_orsha = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 944
-			# owns = 946
-			# owns = 949
-			# has_global_flag = polish_orsha
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = polish_orsha
-			# 944 = { 
-				# change_province_name = "Orsha" 
-				# state_scope = { change_region_name = "Orsha" }
-			# }
-			# 945 = { change_province_name = "Vitebsk" }
-			# 946 = { change_province_name = "Lepiel" }
-			# 948 = { change_province_name = "Mogilev" }
-			# 949 = { change_province_name = "Gomel" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# polish_pinsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 938
-			# owns = 947
-			# owns = 939
-			# NOT = { has_global_flag = polish_pinsk }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_pinsk
-			# set_global_flag = polish_pinsk
-			# 939 = { 
-				# change_province_name = "Pinsk" 
-				# state_scope = { change_region_name = "Pinsk" }
-			# }
-			# 947 = { change_province_name = "Molodeczno" }
-			# 938 = { change_province_name = "Lida" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+		allow = {
+			war = no
+			state_n_government = 1
+		}
 
-	# polish_volyn = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = polish_culture_group
-			# owns = 938
-			# owns = 939
-			# has_global_flag = german_rename_volyn
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_volyn
-			# set_global_flag = polish_volyn
-			# 956 = { 
-				# change_province_name = "Równe" 
-				# state_scope = { change_region_name = "Wolyn" }
-			# }
-			# 957 = { change_province_name = "Kowel" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_minsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 718
-			# owns = 941
-			# owns = 942
-			# NOT = { has_global_flag = german_rename_minsk }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_minsk
-			# clr_global_flag = polish_minsk
-			# 718 = { 
-				# change_province_name = "Minsk" 
-				# state_scope = { change_region_name = "Minsk" }
-			# }
-			# 941 = { change_province_name = "Sluzk" }
-			# 942 = { change_province_name = "Mosyr" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+		effect = {
+			set_global_flag = polish_orsha
+			944 = { change_province_name = "Orsza" }
+			945 = { change_province_name = "Witebsk" }
+			946 = { change_province_name = "Lepel" }
+			948 = {
+				change_province_name = "Moglew"
+				state_scope = { change_region_name = "Moglew" }
+			}
+			949 = { change_province_name = "Gomel" }
+		}
 
-	# degermanize_minsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 718
-			# owns = 941
-			# owns = 942
-			# OR = {
-				# has_global_flag = german_rename_minsk
-				# has_global_flag = polish_minsk
-			# }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_minsk
-			# clr_global_flag = polish_minsk
-			# 718 = { 
-				# change_province_name = "Minsk" 
-				# state_scope = { change_region_name = "Minsk" }
-			# }
-			# 941 = { change_province_name = "Slutsk" }
-			# 942 = { change_province_name = "Mozyr" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_kyiv = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 955
-			# owns = 959
-			# owns = 960
-			# owns = 958
-			# NOT = { has_global_flag = german_rename_kyiv }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_kyiv
-			# clr_global_flag = polish_kyiv
-			# 958 = { 
-				# change_province_name = "Kiew" 
-				# state_scope = { change_region_name = "Kiew" }
-			# }
-			# 960 = { change_province_name = "Schytomyr" }
-			# 959 = { change_province_name = "Korosten" }
-			# 955 = { change_province_name = "Proskorow" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# degermanize_kyiv = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 955
-			# owns = 959
-			# owns = 960
-			# owns = 958
-			# OR = {
-				# has_global_flag = german_rename_kyiv 
-				# has_global_flag = polish_kyiv
-			# }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_kyiv
-			# clr_global_flag = polish_kyiv
-			# 958 = { 
-				# change_province_name = "Kyiv" 
-				# state_scope = { change_region_name = "Kyiv" }
-			# }
-			# 960 = { change_province_name = "Zhitomir" }
-			# 959 = { change_province_name = "Korosten" }
-			# 955 = { change_province_name = "Proskorov" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_brêst = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 936
-			# owns = 937
-			# owns = 940
-			# NOT = { has_global_flag = german_rename_brêst }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_brêst
-			# clr_global_flag = polish_brêst
-			# 937 = { 
-				# change_province_name = "Garten" 
-				# state_scope = { change_region_name = "Brest" }
-			# }
-			# 936 = { change_province_name = "Pruschany" }
-			# 940 = { change_province_name = "Brest-Litowsk" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# degermanize_brêst = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 936
-			# owns = 937
-			# owns = 940
-			# OR = {
-				# has_global_flag = german_rename_brêst
-				# has_global_flag = polish_brêst
-			# }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_brêst
-			# clr_global_flag = polish_brêst
-			# 937 = { 
-				# change_province_name = "Grodno" 
-				# state_scope = { change_region_name = "Brêst" }
-			# }
-			# 936 = { change_province_name = "Pruzhany" }
-			# 940 = { change_province_name = "Brest-Litovsk" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_pinsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 938
-			# owns = 947
-			# owns = 939
-			# NOT = { has_global_flag = german_rename_pinsk }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_pinsk
-			# clr_global_flag = polish_pinsk
-			# 939 = { 
-				# change_province_name = "Pink" 
-				# state_scope = { change_region_name = "Weißrußland" }
-			# }
-			# 947 = { change_province_name = "Mengau" }
-			# 938 = { change_province_name = "Lida" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+		ai_will_do = { factor = 1 }
+	}
 
-	# degermanize_pinsk = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 938
-			# owns = 947
-			# owns = 939
-			# OR = {
-				# has_global_flag = german_rename_pinsk
-				# has_global_flag = polish_pinsk
-			# }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_pinsk
-			# clr_global_flag = polish_pinsk
-			# 939 = { 
-				# change_province_name = "Pinsk" 
-				# state_scope = { change_region_name = "Pinsk" }
-			# }
-			# 947 = { change_province_name = "Maladzyechna" }
-			# 938 = { change_province_name = "Lida" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_volyn = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 938
-			# owns = 939
-			# NOT = { has_global_flag = german_rename_volyn }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_volyn
-			# clr_global_flag = polish_volyn
-			# 956 = { 
-				# change_province_name = "Riwne" 
-				# state_scope = { change_region_name = "Wolhynien" }
-			# }
-			# 957 = { change_province_name = "Koweil" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# degermanize_rename_volyn = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = east_slavic
-			# owns = 938
-			# owns = 939
-			# OR = {
-				# has_global_flag = german_rename_volyn
-				# has_global_flag = polish_volyn
-			# }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_volyn
-			# clr_global_flag = polish_culture_group
-			# 956 = { 
-				# change_province_name = "Rovne" 
-				# state_scope = { change_region_name = "Volyn" }
-			# }
-			# 957 = { change_province_name = "Kovel" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
+	russian_orsha = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 944
+			owns = 946
+			owns = 949
+			has_global_flag = polish_orsha
+		}
 
+		allow = {
+			war = no
+			state_n_government = 1
+		}
 
-	# german_rename_yekaterinoslav = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 961
-			# owns = 971
-			# owns = 972
-			# owns = 970
-			# NOT = { has_global_flag = german_rename_yekaterinoslav }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_yekaterinoslav
-			# 972 = { 
-				# change_province_name = "Alexanderstadt" 
-				# state_scope = { change_region_name = "Niederneper" }
-			# }
-			# 970 = { change_province_name = "Nikolitz" }
-			# 971 = { change_province_name = "Rog" }
-			# 961 = { change_province_name = "Chortiza" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+		effect = {
+			clr_global_flag = polish_orsha
+			944 = { change_province_name = "Orsha" }
+			945 = { change_province_name = "Vitebsk" }
+			946 = { change_province_name = "Lepiel" }
+			948 = {
+				change_province_name = "Mogilev"
+				state_scope = { change_region_name = "Mogilev" }
+			}
+			949 = { change_province_name = "Gomel" }
+		}
 
-	# degermanize_yekaterinoslav = {
-		# picture = gtfo
-		# potential = {
-			# NOT = { is_culture_group = germanic }
-			# owns = 961
-			# owns = 971
-			# owns = 972
-			# owns = 970
-			# has_global_flag = german_rename_yekaterinoslav
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_yekaterinoslav
-			# 972 = { 
-				# change_province_name = "Yekaterinoslav" 
-				# state_scope = { change_region_name = "Yekaterinoslav" }
-			# }
-			# 970 = { change_province_name = "Nikolaev" }
-			# 971 = { change_province_name = "Krivoy Rog" }
-			# 961 = { change_province_name = "Cherkassy" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# german_rename_transnistria = {
-		# picture = gtfo
-		# potential = {
-			# is_culture_group = germanic
-			# owns = 954
-			# owns = 969
-			# owns = 968
-			# NOT = { has_global_flag = german_rename_transnistria }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = german_rename_transnistria
-			# 968 = { 
-				# change_province_name = "Odessa" 
-				# state_scope = { change_region_name = "Greuthungland" }
-			# }
-			# 969 = { change_province_name = "Balta" }
-			# 954 = { change_province_name = "Winnyzja" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# degermanize_transnistria = {
-		# picture = gtfo
-		# potential = {
-			# NOT = { is_culture_group = germanic }
-			# owns = 954
-			# owns = 969
-			# owns = 968
-			# has_global_flag = german_rename_transnistria
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = german_rename_transnistria
-			# 968 = { 
-				# change_province_name = "Odessa" 
-				# state_scope = { change_region_name = "Transnistria" }
-			# }
-			# 969 = { change_province_name = "Balta" }
-			# 954 = { change_province_name = "Vinnitsa" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-		
-	# swedish_rename_ingermanland = {
-		# picture = gtfo
-		# potential = {
-			# OR = {
-				# is_culture_group = scandinavian
-				# tag = SCA
-				# tag = SWE
-			# }
-			# owns = 994
-			# NOT = { has_global_flag = swedish_rename_ingermanland }
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# set_global_flag = swedish_rename_ingermanland
-			# 994 = { 
-				# change_province_name = "Newaborg" 
-				# state_scope = { change_region_name = "Ingermanland" }
-			# }
-			# 996 = { change_province_name = "Letby" }
-			# 997 = { change_province_name = "Gattschina" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
-	# russian_rename_ingermanland = {
-		# picture = gtfo
-		# potential = {
-			# tag = RUS
-			# owns = 994
-			# has_global_flag = swedish_rename_ingermanland
-		# }
-		
-		# allow = {
-			# war = no
-		# }
-		
-		# effect = {
-			# clr_global_flag = swedish_rename_ingermanland
-			# 994 = { 
-				# change_province_name = "St. Petersburg" 
-				# state_scope = { change_region_name = "Ingria" }
-			# }
-			# 996 = { change_province_name = "Luga" }
-			# 997 = { change_province_name = "Gdov" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+		ai_will_do = { factor = 1 }
+	}
+
+## Minsk ##
+
+	german_rename_minsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 718
+					owns = 941
+					owns = 942
+				}
+				718 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_minsk }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_minsk
+			clr_global_flag = polish_minsk
+			718 = {
+				change_province_name = "Minsk"
+				state_scope = { change_region_name = "Minsk" }
+			}
+			941 = { change_province_name = "Sluzk" }
+			942 = { change_province_name = "Mosyr" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_minsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 718
+			owns = 941
+			owns = 942
+			OR = {
+				has_global_flag = german_rename_minsk
+				has_global_flag = polish_minsk
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_minsk
+			clr_global_flag = polish_minsk
+			718 = {
+				change_province_name = "Minsk"
+				state_scope = { change_region_name = "Minsk" }
+			}
+			941 = { change_province_name = "Slutsk" }
+			942 = { change_province_name = "Mozyr" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	polish_minsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 718
+			owns = 941
+			owns = 942
+			NOT = { has_global_flag = polish_minsk }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_minsk
+			set_global_flag = polish_minsk
+			718 = {
+				change_province_name = "Minsk"
+				state_scope = { change_region_name = "Minsk" }
+			}
+			941 = { change_province_name = "Sluck" }
+			942 = { change_province_name = "Mozyrz" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Kiev ##
+
+	german_rename_kyiv = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 955
+					owns = 959
+					owns = 960
+					owns = 958
+				}
+				958 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_kyiv }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_kyiv
+			clr_global_flag = polish_kyiv
+			958 = {
+				change_province_name = "Kiew"
+				state_scope = { change_region_name = "Oberneper" }
+			}
+			960 = { change_province_name = "Uman" }
+			959 = { change_province_name = "Schytomyr" }
+			955 = { change_province_name = "Proskorow" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_kyiv = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 955
+			owns = 959
+			owns = 960
+			owns = 958
+			OR = {
+				has_global_flag = german_rename_kyiv
+				has_global_flag = polish_kyiv
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_kyiv
+			clr_global_flag = polish_kyiv
+			958 = {
+				change_province_name = "Kyiv"
+				state_scope = { change_region_name = "Kyiv" }
+			}
+			960 = { change_province_name = "Uman" }
+			959 = { change_province_name = "Zhitomir" }
+			955 = { change_province_name = "Proskorov" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	polish_kyiv = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 955
+			owns = 959
+			owns = 960
+			owns = 958
+			NOT = { has_global_flag = polish_kyiv }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = polish_kyiv
+			clr_global_flag = german_rename_kyiv
+			958 = {
+				change_province_name = "Kijów"
+				state_scope = { change_region_name = "Kijów" }
+			}
+			960 = { change_province_name = "Human" }
+			959 = { change_province_name = "Zytomierz" }
+			955 = { change_province_name = "Ploskirów" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Brest ##
+
+	german_rename_brest = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 936
+					owns = 937
+					owns = 940
+				}
+				937 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_brest }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_brest
+			clr_global_flag = polish_brest
+			937 = {
+				change_province_name = "Pruschany"
+				state_scope = { change_region_name = "Brest" }
+			}
+			936 = { change_province_name = "Garten" }
+			940 = { change_province_name = "Brest-Litowsk" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_brest = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 936
+			owns = 937
+			owns = 940
+			OR = {
+				has_global_flag = german_rename_brest
+				has_global_flag = polish_brest
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_brest
+			clr_global_flag = polish_brêst
+			937 = {
+				change_province_name = "Pruzhany"
+				state_scope = { change_region_name = "Brêst" }
+			}
+			936 = { change_province_name = "Grodno" }
+			940 = { change_province_name = "Brest-Litovsk" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	polish_brest = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 936
+			owns = 937
+			owns = 940
+			NOT = { has_global_flag = polish_brest }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = polish_brest
+			clr_global_flag = german_rename_brest
+			937 = {
+				change_province_name = "Pruzana"
+				state_scope = { change_region_name = "Brzesc" }
+			}
+			936 = { change_province_name = "Grodno" }
+			940 = { change_province_name = "Brzesc Litewski" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Pinsk ##
+
+	german_rename_pinsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 938
+					owns = 947
+					owns = 939
+				}
+				939 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_pinsk }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_pinsk
+			clr_global_flag = polish_pinsk
+			939 = {
+				change_province_name = "Pinschk"
+				state_scope = { change_region_name = "Weißrußland" }
+			}
+			947 = { change_province_name = "Mengau" }
+			938 = { change_province_name = "Lida" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_pinsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 938
+			owns = 947
+			owns = 939
+			OR = {
+				has_global_flag = german_rename_pinsk
+				has_global_flag = polish_pinsk
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_pinsk
+			clr_global_flag = polish_pinsk
+			939 = {
+				change_province_name = "Pinsk"
+				state_scope = { change_region_name = "Pinsk" }
+			}
+			947 = { change_province_name = "Molodechno" }
+			938 = { change_province_name = "Lida" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	polish_pinsk = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 938
+			owns = 947
+			owns = 939
+			NOT = { has_global_flag = polish_pinsk }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_pinsk
+			set_global_flag = polish_pinsk
+			939 = {
+				change_province_name = "Pinsk"
+				state_scope = { change_region_name = "Pinsk" }
+			}
+			947 = { change_province_name = "Molodeczno" }
+			938 = { change_province_name = "Lida" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Volyn ##
+
+	german_rename_volyn = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 956
+					owns = 957
+				}
+				956 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+
+			NOT = { has_global_flag = german_rename_volyn }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_volyn
+			clr_global_flag = polish_volyn
+			956 = {
+				change_province_name = "Riwne"
+				state_scope = { change_region_name = "Wolhynien" }
+			}
+			957 = { change_province_name = "Koweil" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_volyn = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 956
+			owns = 957
+			OR = {
+				has_global_flag = german_rename_volyn
+				has_global_flag = polish_volyn
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_volyn
+			clr_global_flag = polish_culture_group
+			956 = {
+				change_province_name = "Rovne"
+				state_scope = { change_region_name = "Volyn" }
+			}
+			957 = { change_province_name = "Kovel" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	polish_volyn = {
+		picture = gtfo
+		potential = {
+			is_culture_group = polish_culture_group
+			owns = 956
+			owns = 957
+			has_global_flag = german_rename_volyn
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_volyn
+			set_global_flag = polish_volyn
+			956 = {
+				change_province_name = "Równe"
+				state_scope = { change_region_name = "Wolyn" }
+			}
+			957 = { change_province_name = "Kowel" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Yekaterinoslav ##
+
+	german_rename_yekaterinoslav = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 961
+					owns = 971
+					owns = 972
+					owns = 970
+				}
+				972 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_yekaterinoslav }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_yekaterinoslav
+			972 = {
+				change_province_name = "Alexanderstadt"
+				state_scope = { change_region_name = "Niederneper" }
+			}
+			970 = { change_province_name = "Greuthunger Nikolaus" }
+			971 = { change_province_name = "Elisabethburg" }
+			961 = { change_province_name = "Tscherkassy" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_yekaterinoslav = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 961
+			owns = 971
+			owns = 972
+			owns = 970
+			has_global_flag = german_rename_yekaterinoslav
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_yekaterinoslav
+			any_owned = {
+				limit = {
+					province_id = 972
+					owner = { has_country_flag = names_of_the_revolution }
+				}
+				change_province_name = "Sicheslav"
+			}
+			any_owned = {
+				limit = {
+					province_id = 972
+					owner = { NOT = { has_country_flag = names_of_the_revolution } }
+				}
+				change_province_name = "Yekaterinoslav"
+			}
+			970 = {
+				change_province_name = "Nikolaev"
+				state_scope = { change_region_name = "Yekaterinoslav" }
+			}
+			971 = { change_province_name = "Yelisavetgrad" }
+			961 = { change_province_name = "Cherkassy" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Transnistria ##
+
+	german_rename_transnistria = {
+		picture = gtfo
+		potential = {
+			OR = {
+				AND = {
+					owns = 954
+					owns = 969
+					owns = 968
+				}
+				968 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			is_culture_group = germanic
+			NOT = { has_global_flag = german_rename_transnistria }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_transnistria
+			clr_global_flag = romanian_rename_transnistria
+			968 = {
+				change_province_name = "Odessa"
+				state_scope = { change_region_name = "Greuthungland" }
+			}
+			969 = { change_province_name = "Balta" }
+			954 = { change_province_name = "Winnyzja" }
+			3353 = { change_province_name = "Tiraspol" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_transnistria = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 954
+			owns = 969
+			owns = 968
+			OR = {
+				has_global_flag = german_rename_transnistria
+				has_global_flag = romanian_rename_transnistria
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_transnistria
+			clr_global_flag = romanian_rename_transnistria
+			968 = {
+				change_province_name = "Odessa"
+				state_scope = { change_region_name = "Transnistria" }
+			}
+			969 = { change_province_name = "Balta" }
+			954 = { change_province_name = "Vinnitsa" }
+			3353 = { change_province_name = "Tiraspol" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	romanian_transnistria = {
+		picture = gtfo
+		potential = {
+			primary_culture = romanian
+			owns = 954
+			owns = 969
+			owns = 968
+			NOT = { has_global_flag = romanian_rename_transnistria }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = romanian_rename_transnistria
+			clr_global_flag = german_rename_transnistria
+			968 = {
+				change_province_name = "Odesa"
+				state_scope = { change_region_name = "Transnistria" }
+			}
+			969 = { change_province_name = "Balta" }
+			954 = { change_province_name = "Vinita" }
+			3353 = { change_province_name = "Tiraspol" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Zaporozhia ##
+
+	german_rename_zaporozhia = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 965
+					owns = 973
+					owns = 975
+					owns = 976
+				}
+				973 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_zaporozhia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_zaporozhia
+			clr_global_flag = turkish_rename_zaporozhia
+			clr_global_flag = tatar_rename_zaporozhia
+			965 = { change_province_name = "Cherson" }
+			973 = {
+				change_province_name = "Melitopel"
+				state_scope = { change_region_name = "Nord-Gotenland" }
+			}
+			975 = { change_province_name = "Molotschna" }
+			976 = { change_province_name = "Marienhafen" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_zaporozhia = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 965
+			owns = 973
+			owns = 975
+			owns = 976
+			OR = {
+				has_global_flag = german_rename_zaporozhia
+				has_global_flag = turkish_rename_zaporozhia
+				has_global_flag = tatar_rename_zaporozhia
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_zaporozhia
+			clr_global_flag = turkish_rename_zaporozhia
+			clr_global_flag = tatar_rename_zaporozhia
+			965 = { change_province_name = "Kherson" }
+			973 = {
+				change_province_name = "Melitopol"
+				state_scope = { change_region_name = "Kherson-Zaporozhia" }
+			}
+			975 = { change_province_name = "Berdyansk" }
+			976 = { change_province_name = "Mariupol" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_zaporozhia = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 965
+			owns = 973
+			owns = 975
+			owns = 976
+			NOT = { has_global_flag = turkish_rename_zaporozhia }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = turkish_rename_zaporozhia
+			clr_global_flag = german_rename_zaporozhia
+			clr_global_flag = tatar_rename_zaporozhia
+			965 = { change_province_name = "Herson" }
+			973 = {
+				change_province_name = "Kyzyl-Yar"
+				state_scope = { change_region_name = "Yedisan" }
+			}
+			975 = { change_province_name = "Kutur-Ogly" }
+			976 = { change_province_name = "Izyum" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	tatar_zaporozhia = {
+		picture = gtfo
+		potential = {
+			primary_culture = tatar
+			owns = 965
+			owns = 973
+			owns = 975
+			owns = 976
+			NOT = { has_global_flag = tatar_rename_zaporozhia }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = tatar_rename_zaporozhia
+			clr_global_flag = turkish_rename_zaporozhia
+			clr_global_flag = german_rename_zaporozhia
+			965 = { change_province_name = "Herson" }
+			973 = {
+				change_province_name = "Qiz Yar"
+				state_scope = { change_region_name = "Kherson-Zaporozhia" }
+			}
+			975 = { change_province_name = "Kutur-Ogly" }
+			976 = { change_province_name = "Izüm" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Crimea ##
+
+	german_rename_crimea = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 964
+					owns = 966
+					owns = 967
+				}
+				966 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_crimea }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_crimea
+			clr_global_flag = turkish_rename_crimea
+			clr_global_flag = tatar_rename_crimea
+			964 = { change_province_name = "Theodosia" }
+			966 = {
+				change_province_name = "Gotenburg"
+				state_scope = { change_region_name = "Krim-Gotenland" }
+			}
+			967 = { change_province_name = "Theorodichschafen" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_crimea = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 964
+			owns = 966
+			owns = 967
+			OR = {
+				has_global_flag = german_rename_crimea
+				has_global_flag = turkish_rename_crimea
+				has_global_flag = tatar_rename_crimea
+			}
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_crimea
+			clr_global_flag = turkish_rename_crimea
+			clr_global_flag = tatar_rename_crimea
+			964 = { change_province_name = "Kerch" }
+			966 = {
+				change_province_name = "Simferopol"
+				state_scope = { change_region_name = "Crimea" }
+			}
+			967 = { change_province_name = "Sevastopol" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_crimea = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 964
+			owns = 966
+			owns = 967
+			NOT = { has_global_flag = turkish_rename_crimea }
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = turkish_rename_crimea
+			clr_global_flag = german_rename_crimea
+			clr_global_flag = tatar_rename_crimea
+			964 = { change_province_name = "Kerç" }
+			966 = {
+				change_province_name = "Akmescit"
+				state_scope = { change_region_name = "Kirim" }
+			}
+			967 = { change_province_name = "Akyar" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	tatar_crimea = {
+		picture = gtfo
+		potential = {
+			primary_culture = tatar
+			owns = 964
+			owns = 966
+			owns = 967
+			NOT = { has_global_flag = tatar_rename_crimea }
+			NOT = { overlord = { is_culture_group = germanic } }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = tatar_rename_crimea
+			clr_global_flag = turkish_rename_crimea
+			clr_global_flag = german_rename_crimea
+			964 = { change_province_name = "Keriç" }
+			966 = {
+				change_province_name = "Aqmescit"
+				state_scope = { change_region_name = "Qirim Yurt" }
+			}
+			967 = { change_province_name = "Aqyar" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Kharkiv ##
+
+	german_rename_kharkiv = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 962
+					owns = 963
+					owns = 974
+					owns = 978
+					owns = 980
+				}
+				978 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_kharkiv }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_kharkiv
+			962 = { change_province_name = "Schwartzenberg" }
+			963 = { change_province_name = "Feuersteinplatt" }
+			974 = { change_province_name = "Cherson" }
+			978 = {
+				change_province_name = "Karkau"
+				state_scope = { change_region_name = "Oberdonland" }
+			}
+			980 = { change_province_name = "Molotschna" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_kharkiv = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 965
+			owns = 973
+			owns = 975
+			owns = 976
+			has_global_flag = german_rename_kharkiv
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_kharkiv
+			962 = { change_province_name = "Chernigov" }
+			963 = { change_province_name = "Poltava" }
+			974 = { change_province_name = "Yuzovka" }
+			978 = {
+				change_province_name = "Kharkiv"
+				state_scope = { change_region_name = "Kharhiv" }
+			}
+			980 = { change_province_name = "Lugansk" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Azov ##
+
+	german_rename_azov = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 979
+					owns = 1045
+					owns = 1046
+					owns = 1047
+				}
+				1047 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_azov }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_azov
+			979 = { change_province_name = "Rostow am Don" }
+			1045 = { change_province_name = "Müllerau" }
+			1046 = { change_province_name = "Niedertschar" }
+			1047 = {
+				change_province_name = "Neu-Tscherkassk"
+				state_scope = { change_region_name = "Niederdonland" }
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_azov = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 979
+			owns = 1045
+			owns = 1046
+			owns = 1047
+			has_global_flag = german_rename_azov
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_azov
+			979 = { change_province_name = "Rostov" }
+			1045 = { change_province_name = "Ust-Medveditskaya" }
+			1046 = { change_province_name = "Nizhne-Chirskaya" }
+			1047 = {
+				change_province_name = "Novocherkassk"
+				state_scope = { change_region_name = "Azov" }
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Kuban ##
+
+	german_rename_kuban = {
+		picture = gtfo
+		potential = {
+			is_culture_group = germanic
+			OR = {
+				AND = {
+					owns = 1048
+					owns = 1049
+					owns = 1050
+					owns = 1051
+					owns = 1056
+				}
+				1051 = {
+					owner = {
+						vassal_of = THIS
+					}
+				}
+			}
+			NOT = { has_global_flag = german_rename_kuban }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = german_rename_kuban
+			1048 = { change_province_name = "Kubanburg" }
+			1049 = { change_province_name = "Bata" }
+			1050 = { change_province_name = "Kreuzstadt" }
+			1051 = {
+				change_province_name = "Myekap"
+				state_scope = { change_region_name = "Kuban" }
+			}
+			1056 = { change_province_name = "Fünfbergen" }
+			any_owned = {
+				limit = {
+					province_id = 3352
+				}
+				change_province_name = "Sotschi"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_kuban = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 1048
+			owns = 1049
+			owns = 1050
+			owns = 1051
+			owns = 1056
+			has_global_flag = german_rename_kuban
+			is_vassal = no
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = german_rename_kuban
+			1048 = { change_province_name = "Yekaterinodar" }
+			1049 = { change_province_name = "Novorossiysk" }
+			1050 = { change_province_name = "Stavropol" }
+			1051 = {
+				change_province_name = "Maykop"
+				state_scope = { change_region_name = "Yekaterinodar" }
+			}
+			1056 = { change_province_name = "Pyatigorsk" }
+			any_owned = {
+				limit = {
+					province_id = 3352
+				}
+				change_province_name = "Sochi"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Ingria ##
+
+	swedish_rename_ingermanland = {
+		picture = gtfo
+		potential = {
+			is_culture_group = scandinavian
+			NOT = { primary_culture = finnish }
+			owns = 994
+			NOT = { has_global_flag = swedish_rename_ingermanland }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = swedish_rename_ingermanland
+			994 = {
+				change_province_name = "Newaborg"
+				state_scope = { change_region_name = "Ingermanland" }
+			}
+			996 = { change_province_name = "Letby" }
+			997 = { change_province_name = "Gattschina" }
+			3359 = { change_province_name = "Kirjasalo" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	finnish_rename_ingermanland = {
+		picture = gtfo
+		potential = {
+			primary_culture = finnish
+			owns = 994
+			NOT = { has_global_flag = finnish_rename_ingermanland }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = finnish_rename_ingermanland
+			994 = {
+				change_province_name = "Pietari"
+				state_scope = { change_region_name = "Inkeri" }
+			}
+			996 = { change_province_name = "Laukaa" }
+			997 = { change_province_name = "Outova" }
+			3359 = { change_province_name = "Kirjasalo" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	russian_rename_ingermanland = {
+		picture = gtfo
+		potential = {
+			is_culture_group = east_slavic
+			owns = 994
+			OR = {
+				has_global_flag = swedish_rename_ingermanland
+				has_global_flag = finnish_rename_ingermanland
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = swedish_rename_ingermanland
+			clr_global_flag = finnish_rename_ingermanland
+			any_owned = {
+				limit = {
+					province_id = 994
+					owner = { has_country_flag = names_of_the_revolution }
+				}
+				change_province_name = "Leningrad"
+			}
+			any_owned = {
+				limit = {
+					province_id = 994
+					owner = {
+						NOT = { has_country_flag = names_of_the_revolution }
+						has_country_flag = peters_city_renamed
+					}
+				}
+				change_province_name = "Petrograd"
+			}
+			any_owned = {
+				limit = {
+					province_id = 994
+					owner = {
+						NOT = { has_country_flag = names_of_the_revolution }
+						NOT = { has_country_flag = peters_city_renamed }
+					}
+				}
+				change_province_name = "Sankt-Peterburg"
+			}
+			any_owned = {
+				limit = {
+					province_id = 996
+					owner = { has_country_flag = names_of_the_revolution }
+				}
+				change_province_name = "Petrogradsky"
+			}
+			any_owned = {
+				limit = {
+					province_id = 996
+					owner = { NOT = { has_country_flag = names_of_the_revolution } }
+				}
+				change_province_name = "Luga"
+			}
+			997 = {
+				change_province_name = "Gdov"
+				state_scope = { change_region_name = "Ingria" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 3359
+				}
+				change_province_name = "Koriasilka"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
 }

--- a/TGC/decisions/Renaming-Decisions-TUR.txt
+++ b/TGC/decisions/Renaming-Decisions-TUR.txt
@@ -1,6 +1,273 @@
-political_decisions = { 
+political_decisions = {
 ### OTTOMAN EUROPE ###
+
+## Dobrudja ##
+
+	romanian_rename_dobrudja = {
+		picture = gtfo
+		potential = {
+			primary_culture = romanian
+			OR = {
+				AND = { owns = 818 NOT = { has_global_flag = romanian_rename_dobrudja_818 } }
+				AND = { owns = 674 NOT = { has_global_flag = romanian_rename_dobrudja_674 } }
+				AND = { owns = 675 NOT = { has_global_flag = romanian_rename_dobrudja_675 } }
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = { province_id = 818 }
+				change_province_name = "Darstor"
+				set_global_flag = romanian_rename_dobrudja_818
+				clr_global_flag = bulgarian_rename_dobrudja_818
+			}
+			any_owned = {
+				limit = { province_id = 674 }
+				change_province_name = "Constanta"
+				state_scope = {	change_region_name = "Dobrogea" }
+				set_global_flag = romanian_rename_dobrudja_674
+				clr_global_flag = bulgarian_rename_dobrudja_674
+			}
+			any_owned = {
+				limit = { province_id = 675 }
+				change_province_name = "Tulcea"
+				set_global_flag = romanian_rename_dobrudja_675
+				clr_global_flag = bulgarian_rename_dobrudja_675
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_rename_dobrudja = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			OR = {
+				AND = {
+					owns = 818
+					OR = {
+						has_global_flag = romanian_rename_dobrudja_818
+						has_global_flag = bulgarian_rename_dobrudja_818
+					}
+				}
+				AND = {
+					owns = 674
+					OR = {
+						has_global_flag = romanian_rename_dobrudja_674
+						has_global_flag = bulgarian_rename_dobrudja_674
+					}
+				}
+				AND = {
+					owns = 675
+					OR = {
+						has_global_flag = romanian_rename_dobrudja_675
+						has_global_flag = bulgarian_rename_dobrudja_675
+					}
+				}
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = { province_id = 818 }
+				change_province_name = "Silistre"
+				clr_global_flag = romanian_rename_dobrudja_818
+				clr_global_flag = bulgarian_rename_dobrudja_818
+			}
+			any_owned = {
+				limit = { province_id = 674 }
+				change_province_name = "Köstence"
+				state_scope = {	change_region_name = "Eyalet-i Silistre" }
+				clr_global_flag = romanian_rename_dobrudja_674
+				clr_global_flag = bulgarian_rename_dobrudja_674
+			}
+			any_owned = {
+				limit = { province_id = 675 }
+				change_province_name = "Tolçu"
+				clr_global_flag = romanian_rename_dobrudja_675
+				clr_global_flag = bulgarian_rename_dobrudja_675
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	bulgarian_rename_dobrudja = {
+		picture = gtfo
+		potential = {
+			tag = BUL
+			OR = {
+				AND = { owns = 818 NOT = { has_global_flag = bulgarian_rename_dobrudja_818 } }
+				AND = { owns = 674 NOT = { has_global_flag = bulgarian_rename_dobrudja_674 } }
+				AND = { owns = 675 NOT = { has_global_flag = bulgarian_rename_dobrudja_675 } }
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = { province_id = 818 }
+				change_province_name = "Silistra"
+				clr_global_flag = romanian_rename_dobrudja_818
+				set_global_flag = bulgarian_rename_dobrudja_818
+			}
+			any_owned = {
+				limit = { province_id = 674 }
+				change_province_name = "Konstanca"
+				state_scope = {	change_region_name = "Dobrudja" }
+				clr_global_flag = romanian_rename_dobrudja_674
+				set_global_flag = bulgarian_rename_dobrudja_674
+			}
+			any_owned = {
+				limit = { province_id = 675 }
+				change_province_name = "Tulcha"
+				clr_global_flag = romanian_rename_dobrudja_675
+				set_global_flag = bulgarian_rename_dobrudja_675
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Wallachia ##
+
+	romanian_rename_wallachia = {
+		picture = gtfo
+		potential = {
+			primary_culture = romanian
+			owns = 664
+			has_global_flag = turkish_rename_wallachia
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = turkish_rename_wallachia
+			664 = {
+				change_province_name = "Bucharest"
+				state_scope = {
+					change_region_name = "Teara Rumânesca"
+				}
+			}
+			665 = { change_province_name = "Tirgu Jiu" }
+			666 = { change_province_name = "Craiova" }
+			667 = { change_province_name = "Tirgoviste" }
+			668 = { change_province_name = "Braila" }
+			669 = { change_province_name = "Calarasi" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_rename_wallachia = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 664
+			NOT = { has_global_flag = turkish_rename_wallachia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = turkish_rename_wallachia
+			664 = {
+				change_province_name = "Bükres"
+				state_scope = {
+					change_region_name = "Ulahya"
+				}
+			}
+			665 = { change_province_name = "Tirgu Jiu" }
+			666 = { change_province_name = "Craiova" }
+			667 = { change_province_name = "Tirgoviste" }
+			668 = { change_province_name = "Ibrail" }
+			669 = { change_province_name = "Calarasi" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Moldavia ##
+
+	romanian_rename_moldavia = {
+		picture = gtfo
+		potential = {
+			primary_culture = romanian
+			owns = 670
+			has_global_flag = turkish_rename_moldavia
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = turkish_rename_moldavia
+			670 = {
+				change_province_name = "Iasi"
+				state_scope = {
+					change_region_name = "Moldova"
+				}
+			}
+			671 = { change_province_name = "Botosani" }
+			672 = { change_province_name = "Bacau" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_rename_moldavia = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 670
+			NOT = { has_global_flag = turkish_rename_moldavia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = turkish_rename_moldavia
+			670 = {
+				change_province_name = "Yas"
+				state_scope = {
+					change_region_name = "Bogdan"
+				}
+			}
+			671 = { change_province_name = "Botosani" }
+			672 = { change_province_name = "Bacau" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Bosnia ##
+
 	german_rename_bosnia = {
 		picture = gtfo
 		potential = {
@@ -8,31 +275,30 @@ political_decisions = {
 			owns = 783
 			NOT = { has_global_flag = german_rename_bosnia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = german_rename_bosnia
 			clr_global_flag = slav_rename_bosnia
-			clr_global_flag = turk_rename_bosnia
-			prestige = 2
 			783 = {
 				change_province_name = "Sarajewo"
 				state_scope = {
 					change_region_name = "Bosnien"
-					}
 				}
-			784 = { change_province_name = "Wihitsch" }	
-			785 = { change_province_name = "Weina Luka" }	
-			786 = { change_province_name = "Bieglin" }	
-			787 = { change_province_name = "Fotscha" }	
-			788 = { change_province_name = "Trebing" }	
-			789 = { change_province_name = "Mostar" }	
-			793 = { change_province_name = "Dervent" }	
+			}
+			784 = { change_province_name = "Wihitsch" }
+			785 = { change_province_name = "Weina Luka" }
+			786 = { change_province_name = "Bieglin" }
+			787 = { change_province_name = "Fotscha" }
+			788 = { change_province_name = "Trebing" }
+			789 = { change_province_name = "Mostar" }
+			793 = { change_province_name = "Dervent" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -43,31 +309,30 @@ political_decisions = {
 			owns = 783
 			NOT = { has_global_flag = slav_rename_bosnia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_bosnia
 			set_global_flag = slav_rename_bosnia
-			clr_global_flag = turk_rename_bosnia
-			prestige = 2
 			783 = {
 				change_province_name = "Sarajevo"
 				state_scope = {
 					change_region_name = "Bosna"
-					}
 				}
-			784 = { change_province_name = "Bihac" }	
-			785 = { change_province_name = "Banja Luka" }	
-			786 = { change_province_name = "Bijelijna" }	
-			787 = { change_province_name = "Foca" }	
-			788 = { change_province_name = "Trebinje" }	
-			789 = { change_province_name = "Mostar" }	
-			793 = { change_province_name = "Derventa" }	
+			}
+			784 = { change_province_name = "Bihac" }
+			785 = { change_province_name = "Banja Luka" }
+			786 = { change_province_name = "Bijelijna" }
+			787 = { change_province_name = "Foca" }
+			788 = { change_province_name = "Trebinje" }
+			789 = { change_province_name = "Mostar" }
+			793 = { change_province_name = "Derventa" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -76,37 +341,40 @@ political_decisions = {
 		potential = {
 			primary_culture = turkish
 			owns = 783
-			NOT = { has_global_flag = turk_rename_bosnia }
+			OR = {
+				has_global_flag = german_rename_bosnia
+				has_global_flag = slav_rename_bosnia
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = german_rename_bosnia
 			clr_global_flag = slav_rename_bosnia
-			set_global_flag = turk_rename_bosnia
-			prestige = 2
 			783 = {
 				change_province_name = "Saraybosna"
 				state_scope = {
 					change_region_name = "Bosna"
-					}
 				}
-			784 = { change_province_name = "Bihaç" }	
-			785 = { change_province_name = "Banaluka" }	
-			786 = { change_province_name = "Bijeljina" }	
-			787 = { change_province_name = "Foça" }	
-			788 = { change_province_name = "Trebinye" }	
-			789 = { change_province_name = "Mostar" }	
-			793 = { change_province_name = "Derbent" }	
+			}
+			784 = { change_province_name = "Bihaç" }
+			785 = { change_province_name = "Banaluka" }
+			786 = { change_province_name = "Bijeljina" }
+			787 = { change_province_name = "Foça" }
+			788 = { change_province_name = "Trebinye" }
+			789 = { change_province_name = "Mostar" }
+			793 = { change_province_name = "Derbent" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Kosovo ##
+
 	alb_rename_kosovo = {
 		picture = gtfo
 		potential = {
@@ -114,26 +382,25 @@ political_decisions = {
 			owns = 783
 			NOT = { has_global_flag = alb_rename_kosovo }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = alb_rename_kosovo
 			clr_global_flag = slav_rename_kosovo
-			clr_global_flag = turk_rename_kosovo
-			prestige = 2
 			802 = {
 				change_province_name = "Prishtinë"
 				state_scope = {
 					change_region_name = "Kosovës"
-					}
 				}
-			803 = { change_province_name = "Pejë" }	
-			3321 = { change_province_name = "Mitrovicë" }	
+			}
+			803 = { change_province_name = "Pejë" }
+			3321 = { change_province_name = "Mitrovicë" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -144,26 +411,39 @@ political_decisions = {
 			owns = 783
 			NOT = { has_global_flag = slav_rename_kosovo }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_kosovo
 			set_global_flag = slav_rename_kosovo
-			clr_global_flag = turk_rename_kosovo
-			prestige = 2
 			802 = {
 				change_province_name = "Priština"
 				state_scope = {
 					change_region_name = "Kosovo"
 					}
 				}
-			803 = { change_province_name = "Pec" }	
-			3321 = { change_province_name = "Mitrovica" }	
+			803 = { change_province_name = "Pec" }
+			any_owned = {
+				limit = {
+					province_id = 3321
+					owner = { owns = 791 }
+				}
+				change_province_name = "Kosovska Mitrovica"
+				791 = { change_province_name = "Sremska Mitrovica" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 3321
+					NOT = { owner = { owns = 791 } }
+				}
+				change_province_name = "Mitrovica"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -172,32 +452,35 @@ political_decisions = {
 		potential = {
 			primary_culture = turkish
 			owns = 783
-			NOT = { has_global_flag = turk_rename_kosovo }
+			OR = {
+				has_global_flag = alb_rename_kosovo
+				has_global_flag = slav_rename_kosovo
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_kosovo
 			clr_global_flag = slav_rename_kosovo
-			set_global_flag = turk_rename_kosovo
-			prestige = 2
 			802 = {
 				change_province_name = "Prishtine"
 				state_scope = {
 					change_region_name = "Kosova"
 					}
 				}
-			803 = { change_province_name = "Ipek" }	
-			3321 = { change_province_name = "Mitroviça" }	
+			803 = { change_province_name = "Ipek" }
+			3321 = { change_province_name = "Mitroviça" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Southern Serbia ##
+
 	slav_rename_s_serbia = {
 		picture = gtfo
 		potential = {
@@ -205,26 +488,25 @@ political_decisions = {
 			owns = 804
 			NOT = { has_global_flag = slav_rename_s_serbia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = slav_rename_s_serbia
-			clr_global_flag = turk_rename_s_serbia
-			prestige = 2
-			347 = { change_province_name = "Kruševac" }	
-			798 = { change_province_name = "Niš" }	
-			799 = { change_province_name = "Pirot" }	
+			347 = { change_province_name = "Kruševac" }
+			798 = { change_province_name = "Niš" }
+			799 = { change_province_name = "Pirot" }
 			804 = {
 				change_province_name = "Novi Pazar"
 				state_scope = {
 					change_region_name = "Pomoravlje"
-					}
 				}
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -233,32 +515,32 @@ political_decisions = {
 		potential = {
 			primary_culture = turkish
 			owns = 804
-			NOT = { has_global_flag = turk_rename_s_serbia }
+			has_global_flag = slav_rename_s_serbia
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = slav_rename_s_serbia
-			set_global_flag = turk_rename_s_serbia
-			prestige = 2
-			347 = { change_province_name = "Alacahisar" }	
-			798 = { change_province_name = "Niš" }	
-			799 = { change_province_name = "Šehirköy" }	
+			347 = { change_province_name = "Alacahisar" }
+			798 = { change_province_name = "Niš" }
+			799 = { change_province_name = "Šehirköy" }
 			804 = {
 				change_province_name = "Yeni Pazar"
 				state_scope = {
 					change_region_name = "Niš"
-					}
 				}
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Southern Macedonia ##
+
 	greek_rename_s_macedonia = {
 		picture = gtfo
 		potential = {
@@ -266,19 +548,18 @@ political_decisions = {
 			owns = 820
 			NOT = { has_global_flag = greek_rename_s_macedonia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = greek_rename_s_macedonia
-#			clr_global_flag = serbian_rename_s_macedonia
-			prestige = 2
+			clr_global_flag = serbian_rename_s_macedonia
 			813 = { change_province_name = "Kilkis" }
 			820 = {
-				change_province_name = "Grevena" 
+				change_province_name = "Grevena"
 				state_scope = {
 					change_region_name = "Southern Makedonía"
 				}
@@ -287,28 +568,32 @@ political_decisions = {
 			822 = { change_province_name = "Thessaloníki" }
 			825 = { change_province_name = "Kavala" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_s_macedonia = {
 		picture = gtfo
 		potential = {
 			primary_culture = turkish
 			owns = 821
-			has_global_flag = greek_rename_s_macedonia
+			OR = {
+				has_global_flag = greek_rename_s_macedonia
+				has_global_flag = serbian_rename_s_macedonia
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = greek_rename_s_macedonia
-		#	clr_global_flag = serbian_rename_s_macedonia
+			clr_global_flag = serbian_rename_s_macedonia
 			813 = { change_province_name = "Kilkish" }
 			820 = {
-				change_province_name = "Gerebena" 
+				change_province_name = "Gerebena"
 				state_scope = {
 					change_region_name = "Southern Selânik"
 				}
@@ -317,37 +602,40 @@ political_decisions = {
 			822 = { change_province_name = "Selânik" }
 			825 = { change_province_name = "Kavala" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	# serbian_rename_s_macedonia = {
-		# picture = greater_serbia
-		# potential = {
-			# primary_culture = serb
-			# owns = 821
-			# NOT = { has_global_flag = serbian_rename_s_macedonia }
-		# }
-		
-		# allow = {
-			# war = no
-			# state_n_government = 1
-		# }
-		
-		# effect = {
-			# clr_global_flag = greek_rename_s_macedonia
-			# set_global_flag = serbian_rename_s_macedonia
-			# prestige = 2
-			# 822 = {
-				# change_province_name = "Solun" 
-				# state_scope = {
-					# change_region_name = "Primorska Makedonija"
-				# }
-			# }
-			# 820 = { change_province_name = "Grevená" }
-			# 821 = { change_province_name = "Veria" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
+
+	serbian_rename_s_macedonia = {
+		picture = greater_serbia
+		potential = {
+			primary_culture = serb
+			owns = 821
+			NOT = { has_global_flag = serbian_rename_s_macedonia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = greek_rename_s_macedonia
+			set_global_flag = serbian_rename_s_macedonia
+			813 = { change_province_name = "Kukuš" }
+			822 = {
+				change_province_name = "Solun"
+				state_scope = {
+					change_region_name = "Primorska Makedonija"
+				}
+			}
+			820 = { change_province_name = "Greben" }
+			821 = { change_province_name = "Ber" }
+			825 = { change_province_name = "Kavala" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
 
 	greek_rename_athos = {
 		picture = gtfo
@@ -356,71 +644,112 @@ political_decisions = {
 			owns = 3350
 			NOT = { has_global_flag = greek_rename_athos }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = greek_rename_athos
-			prestige = 1
+			clr_global_flag = serbian_rename_athos
 			3350 = { change_province_name = "Ágion Óros" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_athos = {
 		picture = gtfo
 		potential = {
 			primary_culture = turkish
 			owns = 3350
-			has_global_flag = greek_rename_athos
+			OR = {
+				has_global_flag = greek_rename_athos
+				has_global_flag = serbian_rename_athos
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = greek_rename_athos
+			clr_global_flag = serbian_rename_athos
 			3350 = { change_province_name = "Aynoroz" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
+	serbian_rename_athos = {
+		picture = gtfo
+		potential = {
+			primary_culture = serb
+			owns = 3350
+			NOT = { has_global_flag = serbian_rename_athos }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = serbian_rename_athos
+			clr_global_flag = greek_rename_athos
+			3350 = { change_province_name = "Sveta gora" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Northern Macedonia ##
-	# greek_rename_n_macedonia = {
-		# picture = gtfo
-		# potential = {
-			# primary_culture = greek
-			# owns = 806
-			# NOT = { has_global_flag = greek_rename_n_macedonia }
-		# }
-		
-		# allow = {
-			# war = no
-			# state_n_government = 1
-		# }
-		
-		# effect = {
-			# set_global_flag = greek_rename_n_macedonia
-			# clr_global_flag = bulgarian_rename_n_macedonia
-			# clr_global_flag = serbian_rename_n_macedonia
-			# 806 = {
-				# change_province_name = "Skópia" 
-				# state_scope = {
-					# change_region_name = "Northern Macedonia"
-				# }
-			# }
-			# 807 = { change_province_name = "Monastíri" }
-			# 1780 = { change_province_name = "Dívre" }
-			# prestige = 2
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
+
+	greek_rename_n_macedonia = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 806
+			NOT = { has_global_flag = greek_rename_n_macedonia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = greek_rename_n_macedonia
+			clr_global_flag = bulgarian_rename_n_macedonia
+			clr_global_flag = serbian_rename_n_macedonia
+			806 = {
+				change_province_name = "Skópia"
+				state_scope = {
+					change_region_name = "Northern Macedonia"
+				}
+			}
+			807 = { change_province_name = "Monastíri" }
+			1780 = { change_province_name = "Dívre" }
+			any_owned = {
+				limit = {
+					province_id = 808
+				}
+				change_province_name = "Petritsi"
+			}
+			any_owned = {
+				limit = {
+					province_id = 3291
+				}
+				change_province_name = "Strumnitsa"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 	bulgarian_rename_n_macedonia = {
 		picture = gtfo
 		potential = {
@@ -428,111 +757,148 @@ political_decisions = {
 			owns = 806
 			NOT = { has_global_flag = bulgarian_rename_n_macedonia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bulgarian_rename_n_macedonia
-			#clr_global_flag = greek_rename_n_macedonia
-			#clr_global_flag = serbian_rename_n_macedonia
+			clr_global_flag = greek_rename_n_macedonia
+			clr_global_flag = serbian_rename_n_macedonia
 			806 = {
-				change_province_name = "Skopje" 
+				change_province_name = "Skopje"
 				state_scope = {
 					change_region_name = "Northern Makedoniya"
 				}
 			}
 			807 = { change_province_name = "Bitola" }
-			808 = { change_province_name = "Petrich" }
-			3291 = { change_province_name = "Strumica" }
-			prestige = 2
+			any_owned = {
+				limit = {
+					province_id = 808
+				}
+				change_province_name = "Petrich"
+			}
+			any_owned = {
+				limit = {
+					province_id = 3291
+				}
+				change_province_name = "Strumica"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	# serbian_rename_n_macedonia = {
-		# picture = greater_serbia
-		# potential = {
-			# primary_culture = serb
-			# owns = 806
-			# NOT = { has_global_flag = serbian_rename_n_macedonia }
-		# }
-		
-		# allow = {
-			# war = no
-			# state_n_government = 1
-		# }
-		
-		# effect = {
-			# set_global_flag = serbian_rename_n_macedonia
-			# clr_global_flag = greek_rename_n_macedonia
-			# clr_global_flag = bulgarian_rename_n_macedonia
-			# 806 = {
-				# change_province_name = "Skoplje" 
-				# state_scope = {
-					# change_region_name = "Vardarska Makedonija"
-				# }
-			# }
-			# 807 = { change_province_name = "Bitolj" }
-			# 1780 = { change_province_name = "Debar" }
-			# prestige = 2
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
+
+	serbian_rename_n_macedonia = {
+		picture = greater_serbia
+		potential = {
+			primary_culture = serb
+			owns = 806
+			NOT = { has_global_flag = serbian_rename_n_macedonia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = serbian_rename_n_macedonia
+			clr_global_flag = greek_rename_n_macedonia
+			clr_global_flag = bulgarian_rename_n_macedonia
+			806 = {
+				change_province_name = "Skoplje"
+				state_scope = {
+					change_region_name = "Vardarska Makedonija"
+				}
+			}
+			807 = { change_province_name = "Bitolj" }
+			1780 = { change_province_name = "Debar" }
+			any_owned = {
+				limit = {
+					province_id = 808
+				}
+				change_province_name = "Petric"
+			}
+			any_owned = {
+				limit = {
+					province_id = 3291
+				}
+				change_province_name = "Strumica"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 	turkish_rename_n_macedonia = {
 		picture = gtfo
 		potential = {
 			primary_culture = turkish
 			owns = 806
-			has_global_flag = bulgarian_rename_n_macedonia
+			OR = {
+				has_global_flag = greek_rename_n_macedonia
+				has_global_flag = bulgarian_rename_n_macedonia
+				has_global_flag = serbian_rename_n_macedonia
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
-		#	clr_global_flag = greek_rename_n_macedonia
+			clr_global_flag = greek_rename_n_macedonia
 			clr_global_flag = bulgarian_rename_n_macedonia
-		#	clr_global_flag = serbian_rename_n_macedonia
+			clr_global_flag = serbian_rename_n_macedonia
 			806 = {
-				change_province_name = "Üsküb" 
+				change_province_name = "Üsküb"
 				state_scope = {
 					change_region_name = "Northern Selânik"
 				}
 			}
 			807 = { change_province_name = "Manastir" }
-			808 = { change_province_name = "Petriç" }
-			3291 = { change_province_name = "Ustrumca" }
+			any_owned = {
+				limit = {
+					province_id = 808
+				}
+				change_province_name = "Petriç"
+			}
+			any_owned = {
+				limit = {
+					province_id = 3291
+				}
+				change_province_name = "Ustrumca"
+			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 	bulgarian_rename_debar = {
 		picture = gtfo
 		potential = {
-			is_culture_group = south_slavic
+			tag = BUL
 			owns = 1780
 			NOT = { has_global_flag = bulgarian_rename_debar }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bulgarian_rename_debar
-			prestige = 1
 			1780 = { change_province_name = "Debar" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	alb_rename_debar = {
 		picture = gtfo
 		potential = {
@@ -540,20 +906,20 @@ political_decisions = {
 			owns = 1780
 			NOT = { has_global_flag = alb_rename_debar }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = alb_rename_debar
-			prestige = 1
 			1780 = { change_province_name = "Dibra e Madhe" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_debar = {
 		picture = gtfo
 		potential = {
@@ -564,22 +930,23 @@ political_decisions = {
 				has_global_flag = bulgarian_rename_debar
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = bulgarian_rename_debar
 			clr_global_flag = alb_rename_debar
 			1780 = { change_province_name = "Debre-i Bala" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
+## Eastern Rumelia ##
 
-## Eastern Rumelia ## 
 	bulgaria_rename_rumelia = {
 		picture = gtfo
 		potential = {
@@ -587,19 +954,17 @@ political_decisions = {
 			owns = 815
 			NOT = { has_global_flag = bulgaria_rename_rumelia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bulgaria_rename_rumelia
-#			clr_global_flag = greek_rename_rumelia
-			prestige = 2
-			badboy = -5			
+			clr_global_flag = greek_rename_rumelia
 			815 = {
-				change_province_name = "Plovdiv" 
+				change_province_name = "Plovdiv"
 				state_scope = {
 					change_region_name = "Yuzhna Balgariya"
 				}
@@ -617,56 +982,64 @@ political_decisions = {
 				}
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	# greek_rename_rumelia = {
-		# picture = gtfo
-		# potential = {
-			# primary_culture = greek
-			# owns = 815
-			# NOT = { has_global_flag = greek_rename_rumelia }
-		# }
-		
-		# allow = {
-			# war = no
-			# state_n_government = 1
-		# }
-		
-		# effect = {
-			# set_global_flag = greek_rename_rumelia
-			# clr_global_flag = bulgaria_rename_rumelia
-			# prestige = 2
-			# 815 = {
-				# change_province_name = "Philippopolis" 
-				# state_scope = {
-					# change_region_name = "Northern Thrace"
-				# }
-			# }
-			# 816 = { change_province_name = "Beroe" }
-			# 817 = { change_province_name = "Pyrgos" }
-		# }
-		# ai_will_do = { factor = 1 }
-	# }
-	
+
+	greek_rename_rumelia = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 815
+			NOT = { has_global_flag = greek_rename_rumelia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = greek_rename_rumelia
+			clr_global_flag = bulgaria_rename_rumelia
+			815 = {
+				change_province_name = "Philippopolis"
+				state_scope = {
+					change_region_name = "Northern Thrace"
+				}
+			}
+			816 = { change_province_name = "Beroe" }
+			817 = { change_province_name = "Pyrgos" }
+			2690 = { change_province_name = "Marsa" }
+			3356 = { change_province_name = "Chrysopolis" }
+			3361 = { change_province_name = "Metaxopolis" }
+			3388 = { change_province_name = "Agathopolis" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 	turkish_rename_rumelia = {
 		picture = gtfo
 		potential = {
 			primary_culture = turkish
 			owns = 815
-			has_global_flag = bulgaria_rename_rumelia
+			OR = {
+				has_global_flag = bulgaria_rename_rumelia
+				has_global_flag = greek_rename_rumelia
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = bulgaria_rename_rumelia
-		#	clr_global_flag = greek_rename_rumelia
+			clr_global_flag = greek_rename_rumelia
 			815 = {
-				change_province_name = "Filibe" 
+				change_province_name = "Filibe"
 				state_scope = {
 					change_region_name = "Northern Trakya"
 				}
@@ -677,12 +1050,13 @@ political_decisions = {
 			3356 = { change_province_name = "Daridere" }
 			3361 = { change_province_name = "Cisr-i Mustafapasha" }
 			3388 = { change_province_name = "Ahtabolu" }
-			
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Bulgaria ##
+
 	bulgaria_rename_bulgaria = {
 		picture = gtfo
 		potential = {
@@ -690,19 +1064,18 @@ political_decisions = {
 			owns = 809
 			NOT = { has_global_flag = bulgaria_rename_bulgaria }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bulgaria_rename_bulgaria
-			prestige = 2
 			809 = {
-				change_province_name = "Sofiya" 
+				change_province_name = "Sofiya"
 				state_scope = {
-					change_region_name = "Mizija"
+					change_region_name = "Severna Balgariya"
 				}
 			}
 			810 = { change_province_name = "Vidin" }
@@ -711,9 +1084,10 @@ political_decisions = {
 			814 = { change_province_name = "Varna" }
 			3290 = { change_province_name = "Bosilegrad" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_bulgaria = {
 		picture = gtfo
 		potential = {
@@ -721,18 +1095,18 @@ political_decisions = {
 			owns = 809
 			has_global_flag = bulgaria_rename_bulgaria
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = bulgaria_rename_bulgaria
 			809 = {
-				change_province_name = "Sofya" 
+				change_province_name = "Sofya"
 				state_scope = {
-					change_region_name = "Tuna"
+					change_region_name = "Eyalet-i Rum-eli"
 				}
 			}
 			810 = { change_province_name = "Vidin" }
@@ -741,55 +1115,65 @@ political_decisions = {
 			814 = { change_province_name = "Varna" }
 			3290 = { change_province_name = "Bosilegrad" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Central Macedonia ##
+
 	bulgarian_rename_c_macedonia = {
 		picture = gtfo
 		potential = {
-			is_culture_group = south_slavic
+			tag = BUL
 			owns = 805
 			NOT = { has_global_flag = bulgarian_rename_c_macedonia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
-			set_global_flag = bulgarian_rename_c_macedonia
+			clr_global_flag = serbian_rename_c_macedonia
+			clr_global_flag = greek_rename_c_macedonia
+			has_global_flag = bulgarian_rename_c_macedonia
 			805 = {
-				change_province_name = "Enidže Vardar" 
+				change_province_name = "Enidže Vardar"
 				state_scope = {
 					change_region_name = "Central Makedoniya"
 				}
 			}
 			819 = { change_province_name = "Kostur" }
 			823 = { change_province_name = "Ser" }
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-		
+
 	turkish_rename_c_macedonia = {
 		picture = gtfo
 		potential = {
 			primary_culture = turkish
 			owns = 805
-			has_global_flag = bulgarian_rename_c_macedonia
+			OR = {
+				has_global_flag = serbian_rename_c_macedonia
+				has_global_flag = greek_rename_c_macedonia
+				has_global_flag = bulgarian_rename_c_macedonia
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
+			clr_global_flag = serbian_rename_c_macedonia
+			clr_global_flag = greek_rename_c_macedonia
 			clr_global_flag = bulgarian_rename_c_macedonia
 			805 = {
-				change_province_name = "Yenice-i Vardar" 
+				change_province_name = "Yenice-i Vardar"
 				state_scope = {
 					change_region_name = "Central Selânik"
 				}
@@ -797,17 +1181,78 @@ political_decisions = {
 			819 = { change_province_name = "Kesriye" }
 			823 = { change_province_name = "Siroz" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
+	greek_rename_c_macedonia = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 805
+			NOT = { has_global_flag = greek_rename_c_macedonia }
+		}
 
-## Eprius ##	
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = serbian_rename_c_macedonia
+			set_global_flag = greek_rename_c_macedonia
+			clr_global_flag = bulgarian_rename_c_macedonia
+			805 = {
+				change_province_name = "Giannitsa"
+				state_scope = {
+					change_region_name = "Central Makedoniya"
+				}
+			}
+			819 = { change_province_name = "Kastoria" }
+			823 = { change_province_name = "Serres" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	serbian_rename_c_macedonia = {
+		picture = gtfo
+		potential = {
+			primary_culture = serb
+			owns = 805
+			NOT = { has_global_flag = serbian_rename_c_macedonia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = serbian_rename_c_macedonia
+			clr_global_flag = greek_rename_c_macedonia
+			clr_global_flag = bulgarian_rename_c_macedonia
+			805 = {
+				change_province_name = "Pazar"
+				state_scope = {
+					change_region_name = "Centralna Makedonija"
+				}
+			}
+			819 = { change_province_name = "Kostur" }
+			823 = { change_province_name = "Serez" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Eprius ##
+
 	greek_rename_epirus = {
 		picture = gtfo
 		potential = {
 			primary_culture = greek
-			OR = { 
-				AND = { 
+			OR = {
+				AND = {
 					owns = 824
 					NOT = { has_global_flag = greek_rename_epirus_824 }
 				}
@@ -821,43 +1266,41 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
 					province_id = 824
 				}
-				824 = { change_province_name = "Ioannina" }
-				824 = { state_scope =
-						{ change_region_name = "Ípiros" }
-					}
+				change_province_name = "Ioannina"
+				state_scope = { change_region_name = "Ípiros" }
 				set_global_flag = greek_rename_epirus_824
 			}
 			random_owned = {
 				limit = {
 					province_id = 841
 				}
-				841 = { change_province_name = "Metsovo" }
+				change_province_name = "Metsovo"
 				set_global_flag = greek_rename_epirus_841
 			}
 			random_owned = {
 				limit = {
 					province_id = 853
 				}
-				853 = { change_province_name = "Argyrokastro" }
+				change_province_name = "Argyrokastro"
 				set_global_flag = greek_rename_epirus_853
 				clr_global_flag = albanian_rename_epirus_853
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	albanian_rename_epirus = {
 		picture = gtfo
 		potential = {
@@ -865,12 +1308,12 @@ political_decisions = {
 			owns = 853
 			NOT = { has_global_flag = albanian_rename_epirus_853 }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
@@ -880,11 +1323,11 @@ political_decisions = {
 				set_global_flag = albanian_rename_epirus_853
 				clr_global_flag = greek_rename_epirus_853
 			}
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_epirus = {
 		picture = gtfo
 		potential = {
@@ -899,30 +1342,166 @@ political_decisions = {
 				has_global_flag = greek_rename_epirus_853
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = albanian_rename_epirus_853
 			clr_global_flag = greek_rename_epirus_824
 			clr_global_flag = greek_rename_epirus_841
 			clr_global_flag = greek_rename_epirus_853
-			824 = { change_province_name = "Janina" }
-			824 = { state_scope =
-					{ change_region_name = "Yanya" }
+			824 = {
+				change_province_name = "Janina"
+				state_scope = { change_region_name = "Yanya" }
+			}
 			841 = { change_province_name = "Miçova" }
 			853 = { change_province_name = "Ergiri Kasri" }
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Peloponnese ##
 
+	greek_rename_peloponnese = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 839
+			owns = 840
+			owns = 842
+			has_global_flag = turkish_rename_peloponnese
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = turkish_rename_peloponnese
+			839 = {
+				change_province_name = "Náfplion"
+				state_scope = { change_region_name = "Peloponnisos" }
+			}
+			840 = { change_province_name = "Kórinthos" }
+			842 = { change_province_name = "Pátrai" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_rename_peloponnese = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 839
+			owns = 840
+			owns = 842
+			NOT = { has_global_flag = turkish_rename_peloponnese }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = turkish_rename_peloponnese
+			839 = {
+				change_province_name = "Anabolu"
+				state_scope = { change_region_name = "Mora Yarimadasi" }
+			}
+			840 = { change_province_name = "Gördös" }
+			842 = { change_province_name = "Balyabadra" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Ionian Islands ##
+
+	greek_rename_ionian_islands = {
+		picture = gtfo
+		potential = {
+			primary_culture = italian
+			owns = 827
+			owns = 826
+			OR = {
+				has_global_flag = italian_rename_ionian_islands
+				has_global_flag = turkish_rename_ionian_islands
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = italian_rename_ionian_islands
+			clr_global_flag = turkish_rename_ionian_islands
+			827 = { change_province_name = "Zakynthos" }
+			826 = { change_province_name = "Kerkyra" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	turkish_rename_ionian_islands = {
+		picture = gtfo
+		potential = {
+			primary_culture = italian
+			owns = 827
+			owns = 826
+			NOT = { has_global_flag = turkish_rename_ionian_islands }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = italian_rename_ionian_islands
+			set_global_flag = turkish_rename_ionian_islands
+			827 = { change_province_name = "Zante" }
+			826 = { change_province_name = "Korfu" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	italian_rename_ionian_islands = {
+		picture = gtfo
+		potential = {
+			primary_culture = italian
+			owns = 827
+			owns = 826
+			NOT = { has_global_flag = italian_rename_ionian_islands }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = italian_rename_ionian_islands
+			clr_global_flag = turkish_rename_ionian_islands
+			827 = { change_province_name = "Zante" }
+			826 = { change_province_name = "Korfu" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Western Thrace ##
+
 	greek_rename_e_macedonia = {
 		picture = gtfo
 		potential = {
@@ -930,28 +1509,28 @@ political_decisions = {
 			owns = 830
 			NOT = { has_global_flag = greek_rename_e_macedonia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = greek_rename_e_macedonia
 			clr_global_flag = bulgarian_rename_e_macedonia
 			829 = { change_province_name = "Xánthi" }
 			830 = {
-				change_province_name = "Didymoteicho" 
+				change_province_name = "Didymoteicho"
 				state_scope = {
 					change_region_name = "Western Thráki"
 				}
 			}
 			851 = { change_province_name = "Komotini" }
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	bulgarian_rename_e_macedonia = {
 		picture = gtfo
 		potential = {
@@ -959,28 +1538,28 @@ political_decisions = {
 			owns = 830
 			NOT = { has_global_flag = bulgarian_rename_e_macedonia }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = bulgarian_rename_e_macedonia
 			clr_global_flag = greek_rename_e_macedonia
 			829 = { change_province_name = "Ksanti" }
 			830 = {
-				change_province_name = "Dimotika" 
+				change_province_name = "Dimotika"
 				state_scope = {
 					change_region_name = "Western Trakiya"
 				}
 			}
 			851 = { change_province_name = "Gyumyurdjina" }
-			prestige = 2
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	turkish_rename_e_macedonia = {
 		picture = gtfo
 		potential = {
@@ -991,34 +1570,462 @@ political_decisions = {
 				has_global_flag = greek_rename_e_macedonia
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = bulgarian_rename_e_macedonia
 			clr_global_flag = greek_rename_e_macedonia
 			829 = { change_province_name = "Iskeçe" }
 			830 = {
-				change_province_name = "Dimetoka" 
+				change_province_name = "Dimetoka"
 				state_scope = {
 					change_region_name = "Western Trakya"
 				}
 			}
 			851 = { change_province_name = "Gümülcine" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 ## Thessalia ##
+
+	turkish_rename_thessalia = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 831
+			owns = 831
+			owns = 833
+			has_global_flag = greek_rename_thessalia
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = greek_rename_thessalia
+			831 = { change_province_name = "Alasonya" }
+			832 = { change_province_name = "Quluz" }
+			833 = {
+				change_province_name = "Tirhala"
+				state_scope = { change_region_name = "Tirhala Sanjak" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 836
+				}
+				change_province_name = "Lamya"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	greek_rename_thessalia = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 831
+			owns = 831
+			owns = 833
+			NOT = { has_global_flag = greek_rename_thessalia }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			set_global_flag = greek_rename_thessalia
+			831 = { change_province_name = "Elassona" }
+			832 = { change_province_name = "Volos" }
+			833 = {
+				change_province_name = "Trikala"
+				state_scope = { change_region_name = "Thessalía" }
+			}
+			any_owned = {
+				limit = {
+					province_id = 836
+				}
+				change_province_name = "Lamía"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
 
 ## Continental Greece ##
 
+	turkish_rename_continental_greece = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			owns = 834
+			owns = 835
+			owns = 837
+			owns = 838
+			NOT = { has_global_flag = turkish_rename_continental_greece }
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = turkish_rename_continental_greece
+			834 = {
+				change_province_name = "Atina"
+				state_scope = { change_region_name = "Orta Yunanistan" }
+			}
+			835 = { change_province_name = "Amfissa" }
+			837 = { change_province_name = "Etolya-Akarnanya" }
+			838 = { change_province_name = "Egriboz" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	greek_rename_continental_greece = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			owns = 834
+			owns = 835
+			owns = 837
+			owns = 838
+			has_global_flag = turkish_rename_continental_greece
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			clr_global_flag = turkish_rename_continental_greece
+			834 = {
+				change_province_name = "Athínai"
+				state_scope = { change_region_name = "Stereá Elláda" }
+			}
+			835 = { change_province_name = "Ámfissa" }
+			837 = { change_province_name = "Aitoloakarnanía" }
+			838 = { change_province_name = "Chalkís" }
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Aegean Islands ##
 
+	turkish_rename_aegean_islands = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			OR = {
+				AND = {
+					OR = {
+						owns = 843
+						843 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = greek_rename_843
+				}
+				AND = {
+					OR = {
+						owns = 844
+						844 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = greek_rename_844
+				}
+				AND = {
+					OR = {
+						owns = 845
+						845 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = turkish_rename_845 }
+				}
+				AND = {
+					OR = {
+						owns = 846
+						846 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = greek_rename_846
+				}
+				AND = {
+					AND = {
+						OR = {
+							owns = 847
+							847 = { owner = { vassal_of = THIS } }
+						}
+						OR = {
+							owns = 848
+							848 = {	owner = { vassal_of = THIS } }
+						}
+					}
+					has_global_flag = greek_rename_crete
+				}
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = {
+					province_id = 843
+				}
+				change_province_name = "Sisam"
+				clr_global_flag = greek_rename_843
+			}
+			any_owned = {
+				limit = {
+					province_id = 844
+				}
+				change_province_name = "Midilli"
+				clr_global_flag = greek_rename_844
+			}
+			any_owned = {
+				limit = {
+					province_id = 845
+				}
+				change_province_name = "Kiklad Adalari"
+				set_global_flag = turkish_rename_845
+			}
+			any_owned = {
+				limit = {
+					province_id = 846
+				}
+				change_province_name = "Mentese Adalari"
+				clr_global_flag = greek_rename_846
+			}
+			any_owned = {
+				limit = {
+					province_id = 847
+				}
+				change_province_name = "Hanya"
+				clr_global_flag = greek_rename_crete
+			}
+			any_owned = {
+				limit = {
+					province_id = 848
+				}
+				change_province_name = "Kandiye"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	greek_rename_aegean_islands = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			OR = {
+				AND = {
+					OR = {
+						owns = 843
+						843 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = greek_rename_843 }
+				}
+				AND = {
+					OR = {
+						owns = 844
+						844 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = greek_rename_844 }
+				}
+				AND = {
+					OR = {
+						owns = 845
+						845 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = turkish_rename_845
+				}
+				AND = {
+					OR = {
+						owns = 846
+						846 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = greek_rename_846 }
+				}
+				AND = {
+					AND = {
+						OR = {
+							owns = 847
+							847 = { owner = { vassal_of = THIS } }
+						}
+						OR = {
+							owns = 848
+							848 = {	owner = { vassal_of = THIS } }
+						}
+					}
+					NOT = { has_global_flag = greek_rename_crete }
+				}
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = {
+					province_id = 843
+				}
+				change_province_name = "Samos"
+				set_global_flag = greek_rename_843
+			}
+			any_owned = {
+				limit = {
+					province_id = 844
+				}
+				change_province_name = "Lesbos"
+				set_global_flag = greek_rename_844
+			}
+			any_owned = {
+				limit = {
+					province_id = 845
+				}
+				change_province_name = "Kykládes"
+				clr_global_flag = turkish_rename_845
+			}
+			any_owned = {
+				limit = {
+					province_id = 846
+				}
+				change_province_name = "Dodecanese"
+				set_global_flag = greek_rename_846
+			}
+			any_owned = {
+				limit = {
+					province_id = 847
+				}
+				change_province_name = "Chania"
+				set_global_flag = greek_rename_crete
+			}
+			any_owned = {
+				limit = {
+					province_id = 848
+				}
+				change_province_name = "Heraklion"
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+## Cyprus ##
+
+	turkish_rename_cyprus = {
+		picture = gtfo
+		potential = {
+			primary_culture = turkish
+			OR = {
+				AND = {
+					OR = {
+						owns = 855
+						855 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = greek_rename_855
+				}
+				AND = {
+					OR = {
+						owns = 857
+						857 = {	owner = { vassal_of = THIS } }
+					}
+					has_global_flag = greek_rename_857
+				}
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = {
+					province_id = 855
+				}
+				change_province_name = "Lefkosa"
+				clr_global_flag = greek_rename_855
+			}
+			any_owned = {
+				limit = {
+					province_id = 857
+				}
+				change_province_name = "Gazimagusa"
+				clr_global_flag = greek_rename_857
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	greek_rename_cyprus = {
+		picture = gtfo
+		potential = {
+			primary_culture = greek
+			OR = {
+				AND = {
+					OR = {
+						owns = 855
+						855 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = greek_rename_855 }
+				}
+				AND = {
+					OR = {
+						owns = 857
+						857 = {	owner = { vassal_of = THIS } }
+					}
+					NOT = { has_global_flag = greek_rename_857 }
+				}
+			}
+		}
+
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+
+		effect = {
+			any_owned = {
+				limit = {
+					province_id = 855
+				}
+				change_province_name = "Nicosia"
+				set_global_flag = greek_rename_855
+			}
+			any_owned = {
+				limit = {
+					province_id = 857
+				}
+				change_province_name = "Famagusta"
+				set_global_flag = greek_rename_857
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
 ## Albania ##
+
 	alb_rename_albania = {
 		picture = gtfo
 		potential = {
@@ -1026,26 +2033,25 @@ political_decisions = {
 			owns = 849
 			NOT = { has_global_flag = alb_rename_albania }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = alb_rename_albania
 			clr_global_flag = slav_rename_albania
-			clr_global_flag = turk_rename_albania
-			prestige = 2
 			849 = {
 				change_province_name = "Tiranë"
 				state_scope = {
 					change_region_name = "Shopëri"
-					}
 				}
-			850 = { change_province_name = "Shkodër" }	
-			852 = { change_province_name = "Vlorë" }	
+			}
+			850 = { change_province_name = "Shkodër" }
+			852 = { change_province_name = "Vlorë" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1056,26 +2062,25 @@ political_decisions = {
 			owns = 849
 			NOT = { has_global_flag = slav_rename_albania }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_albania
 			set_global_flag = slav_rename_albania
-			clr_global_flag = turk_rename_albania
-			prestige = 2
 			849 = {
 				change_province_name = "Tirana"
 				state_scope = {
 					change_region_name = "Albanija"
-					}
 				}
-			850 = { change_province_name = "Skadar" }	
-			852 = { change_province_name = "Valona" }	
+			}
+			850 = { change_province_name = "Skadar" }
+			852 = { change_province_name = "Valona" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1084,32 +2089,35 @@ political_decisions = {
 		potential = {
 			primary_culture = turkish
 			owns = 849
-			NOT = { has_global_flag = turk_rename_albania }
+			OR = {
+				has_global_flag = alb_rename_albania
+				has_global_flag = slav_rename_albania
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_albania
 			clr_global_flag = slav_rename_albania
-			set_global_flag = turk_rename_albania
-			prestige = 2
 			849 = {
 				change_province_name = "Tiran"
 				state_scope = {
 					change_region_name = "Iskodra"
-					}
 				}
-			850 = { change_province_name = "Iskodra" }	
-			852 = { change_province_name = "Avlonya" }	
+			}
+			850 = { change_province_name = "Iskodra" }
+			852 = { change_province_name = "Avlonya" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
 ## Mala Prespa ##
+
 	alb_rename_prespa = {
 		picture = gtfo
 		potential = {
@@ -1117,25 +2125,24 @@ political_decisions = {
 			owns = 3365
 			NOT = { has_global_flag = alb_rename_prespa }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = alb_rename_prespa
 			clr_global_flag = slav_rename_prespa
-			clr_global_flag = turk_rename_prespa
-			prestige = 2
 			3365 = {
 				change_province_name = "Korçës"
 				state_scope = {
 					change_region_name = "Korçës"
-					}
 				}
-			3364 = { change_province_name = "Peshkopi" }	
+			}
+			3364 = { change_province_name = "Peshkopi" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1146,25 +2153,24 @@ political_decisions = {
 			owns = 3365
 			NOT = { has_global_flag = slav_rename_prespa }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_prespa
 			set_global_flag = slav_rename_prespa
-			clr_global_flag = turk_rename_prespa
-			prestige = 2
 			3365 = {
 				change_province_name = "Goritsa"
 				state_scope = {
 					change_region_name = "Mala Prespa"
-					}
 				}
-			3364 = { change_province_name = "Peškopija" }	
+			}
+			3364 = { change_province_name = "Peškopija" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1173,30 +2179,31 @@ political_decisions = {
 		potential = {
 			primary_culture = turkish
 			owns = 3365
-			NOT = { has_global_flag = turk_rename_prespa }
+			OR = {
+				has_global_flag = alb_rename_prespa
+				has_global_flag = slav_rename_prespa
+			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			clr_global_flag = alb_rename_prespa
 			clr_global_flag = slav_rename_prespa
-			set_global_flag = turk_rename_prespa
-			prestige = 2
 			3365 = {
 				change_province_name = "Görice"
 				state_scope = {
 					change_region_name = "Görice"
-					}
 				}
-			3364 = { change_province_name = "Debre-i Zir" }	
+			}
+			3364 = { change_province_name = "Debre-i Zir" }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-
 
 #from Flavour_Mod_Balkans.txt
 	turkification = {
@@ -1211,15 +2218,14 @@ political_decisions = {
 				AND = { owns = 828 NOT = { has_country_flag = turkification_edirne } }
 				AND = { owns = 859 NOT = { has_country_flag = turkification_gelibolu } }
 				AND = { owns = 861 NOT = { has_country_flag = turkification_uskudar } }
-				
 			}
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
@@ -1264,515 +2270,543 @@ political_decisions = {
 				owner = { set_country_flag = turkification_uskudar }
 			}
 		}
+
 		ai_will_do = { factor = 1 }
 	}
+
 ########################################
 #          Renaming Decisions          #
 # Greek names are courtesy of dherve10 #
 ########################################
 
-byzantine_anatolia = {
-	potential = {
-		tag = BYZ
-		OR = {
-			owns = 876 #Ankara
-			owns = 894 #Adana
-			owns = 880 #Kastamonu
-			owns = 873 #Konya
-			owns = 882 #Trabzon
-		}
-		NOT = { has_global_flag = anatolia_renamed }
-	}
-	allow = {
-		owns = 876 #Ankara
-		owns = 894 #Adana
-		owns = 880 #Kastamonu
-		owns = 873 #Konya
-		owns = 882 #Trabzon
-		war = no
-	}
-	effect = {
-		870 = {
-			change_province_name = "Magnesia"
-		}
-		871 = {
-			change_province_name = "Psidia"
-		}
-		867 = {
-			change_province_name = "Kotyaion"
-		}
-		876 = {
-			change_province_name = "Ancyra"
-			state_scope = { change_region_name = "Paphlagonia"}
-		}
-		868 = {
-			change_province_name = "Phrygia"
-		}
-		877 = {
-			change_province_name = "Amaseia"
-		}
-		878 = {
-			change_province_name = "Kaisereia"
-		}
-		894 = {
-			change_province_name = "Tarsos"
-			state_scope = { change_region_name = "Cilicia" }
-		}
-		895 = {
-			change_province_name = "Seleukeia"
-		}
-		896 = {
-			change_province_name = "Telouch"
-		}
-		898 = {
-			change_province_name = "Aintab"
-		}
-		880 = {
-			change_province_name = "Paphlagonia"
-			state_scope = { change_region_name = "Armeniacon" }
-		}
-		881 = {
-			change_province_name = "Bithynia"
-		}
-		883 = {
-			change_province_name = "Sinope"
-		}
-		873 = {
-			change_province_name = "Ikonion"
-			state_scope = { change_region_name = "Anatolia"}
-		}
-		866 ={
-			change_province_name = "Sozopolis"
-		}
-		874 = {
-			change_province_name = "Laodikeia"
-		}
-		875 = {
-			change_province_name = "Attaleia"
-		}
-		882 = {
-			change_province_name = "Chaldia"
-			state_scope = { change_region_name = "Trebizond" }
-		}
-		884 = {
-			change_province_name = "Pontos"
-		}
-		879 = {
-			change_province_name = "Sebasteia"
-		}
-		888 = {
-			change_province_name = "Koloneia"
-		}
-		prestige = 2
-		set_global_flag = anatolia_renamed
-	}
-}
-
-restore_anatolia = {
-	potential = {
-		tag = TUR
-		has_global_flag = anatolia_renamed
-		OR = {
-			owns = 876 #Ankara
-			owns = 894 #Adana
-			owns = 880 #Kastamonu
-			owns = 873 #Konya
-			owns = 882 #Trabzon
-		}
-	}
-	allow = {
-		owns = 876 #Ankara
-		owns = 894 #Adana
-		owns = 880 #Kastamonu
-		owns = 873 #Konya
-		owns = 882 #Trabzon
-		war = no
-	}
-	effect = {
-		870 = {
-			change_province_name = "Manisa"
-		}
-		871 = {
-			change_province_name = "Denizli"
-		}
-		867 = {
-			change_province_name = "Kütahya"
-		}
-		876 = {
-			change_province_name = "Ankara"
-			state_scope = { change_region_name = "Ankara"}
-		}
-		868 = {
-			change_province_name = "Eskishehir"
-		}
-		877 = {
-			change_province_name = "Amasya"
-		}
-		878 = {
-			change_province_name = "Kayseri"
-		}
-		894 = {
-			change_province_name = "Adana"
-			state_scope = { change_region_name = "Adana" }
-		}
-		895 = {
-			change_province_name = "Mersin"
-		}
-		896 = {
-			change_province_name = "Marash"
-		}
-		898 = {
-			change_province_name = "Antep"
-		}
-		880 = {
-			change_province_name = "Kastamonu"
-			state_scope = { change_region_name = "Kastamonu" }
-		}
-		881 = {
-			change_province_name = "Bolu"
-		}
-		883 = {
-			change_province_name = "Sinop"
-		}
-		873 = {
-			change_province_name = "Konya"
-			state_scope = { change_region_name = "Konya"}
-		}
-		866 ={
-			change_province_name = "Afyon"
-		}
-		874 = {
-			change_province_name = "Burdur"
-		}
-		875 = {
-			change_province_name = "Antalya"
-		}
-		882 = {
-			change_province_name = "Trabzon"
-			state_scope = { change_region_name = "Trabzon" }
-		}
-		884 = {
-			change_province_name = "Giresun"
-		}
-		879 = {
-			change_province_name = "Sivas"
-		}
-		888 = {
-			change_province_name = "Erzincan"
-		}
-		random_country = {
-				limit = {
-					exists = yes
-					tag = BYZ
-				}
-				prestige = -3
+	byzantine_anatolia = {
+		potential = {
+			tag = BYZ
+			OR = {
+				owns = 876 #Ankara
+				owns = 894 #Adana
+				owns = 880 #Kastamonu
+				owns = 873 #Konya
+				owns = 882 #Trabzon
 			}
-			clr_global_flag = anatolia_renamed
-	}
-}
+			NOT = { has_global_flag = anatolia_renamed }
+		}
 
-byzantine_armenia = {
-	potential = {
-		tag = BYZ
-		OR = {
+		allow = {
+			owns = 876 #Ankara
+			owns = 894 #Adana
+			owns = 880 #Kastamonu
+			owns = 873 #Konya
+			owns = 882 #Trabzon
+			war = no
+		}
+
+		effect = {
+			870 = {
+				change_province_name = "Magnesia"
+			}
+			871 = {
+				change_province_name = "Psidia"
+			}
+			867 = {
+				change_province_name = "Kotyaion"
+			}
+			876 = {
+				change_province_name = "Ancyra"
+				state_scope = { change_region_name = "Paphlagonia"}
+			}
+			868 = {
+				change_province_name = "Phrygia"
+			}
+			877 = {
+				change_province_name = "Amaseia"
+			}
+			878 = {
+				change_province_name = "Kaisereia"
+			}
+			894 = {
+				change_province_name = "Tarsos"
+				state_scope = { change_region_name = "Cilicia" }
+			}
+			895 = {
+				change_province_name = "Seleukeia"
+			}
+			896 = {
+				change_province_name = "Telouch"
+			}
+			898 = {
+				change_province_name = "Aintab"
+			}
+			880 = {
+				change_province_name = "Paphlagonia"
+				state_scope = { change_region_name = "Armeniacon" }
+			}
+			881 = {
+				change_province_name = "Bithynia"
+			}
+			883 = {
+				change_province_name = "Sinope"
+			}
+			873 = {
+				change_province_name = "Ikonion"
+				state_scope = { change_region_name = "Anatolia"}
+			}
+			866 ={
+				change_province_name = "Sozopolis"
+			}
+			874 = {
+				change_province_name = "Laodikeia"
+			}
+			875 = {
+				change_province_name = "Attaleia"
+			}
+			882 = {
+				change_province_name = "Chaldia"
+				state_scope = { change_region_name = "Trebizond" }
+			}
+			884 = {
+				change_province_name = "Pontos"
+			}
+			879 = {
+				change_province_name = "Sebasteia"
+			}
+			888 = {
+				change_province_name = "Koloneia"
+			}
+			prestige = 2
+			set_global_flag = anatolia_renamed
+		}
+	}
+
+	restore_anatolia = {
+		potential = {
+			tag = TUR
+			has_global_flag = anatolia_renamed
+			OR = {
+				owns = 876 #Ankara
+				owns = 894 #Adana
+				owns = 880 #Kastamonu
+				owns = 873 #Konya
+				owns = 882 #Trabzon
+			}
+		}
+
+		allow = {
+			owns = 876 #Ankara
+			owns = 894 #Adana
+			owns = 880 #Kastamonu
+			owns = 873 #Konya
+			owns = 882 #Trabzon
+			war = no
+		}
+
+		effect = {
+			870 = {
+				change_province_name = "Manisa"
+			}
+			871 = {
+				change_province_name = "Denizli"
+			}
+			867 = {
+				change_province_name = "Kütahya"
+			}
+			876 = {
+				change_province_name = "Ankara"
+				state_scope = { change_region_name = "Ankara"}
+			}
+			868 = {
+				change_province_name = "Eskishehir"
+			}
+			877 = {
+				change_province_name = "Amasya"
+			}
+			878 = {
+				change_province_name = "Kayseri"
+			}
+			894 = {
+				change_province_name = "Adana"
+				state_scope = { change_region_name = "Adana" }
+			}
+			895 = {
+				change_province_name = "Mersin"
+			}
+			896 = {
+				change_province_name = "Marash"
+			}
+			898 = {
+				change_province_name = "Antep"
+			}
+			880 = {
+				change_province_name = "Kastamonu"
+				state_scope = { change_region_name = "Kastamonu" }
+			}
+			881 = {
+				change_province_name = "Bolu"
+			}
+			883 = {
+				change_province_name = "Sinop"
+			}
+			873 = {
+				change_province_name = "Konya"
+				state_scope = { change_region_name = "Konya"}
+			}
+			866 ={
+				change_province_name = "Afyon"
+			}
+			874 = {
+				change_province_name = "Burdur"
+			}
+			875 = {
+				change_province_name = "Antalya"
+			}
+			882 = {
+				change_province_name = "Trabzon"
+				state_scope = { change_region_name = "Trabzon" }
+			}
+			884 = {
+				change_province_name = "Giresun"
+			}
+			879 = {
+				change_province_name = "Sivas"
+			}
+			888 = {
+				change_province_name = "Erzincan"
+			}
+			random_country = {
+					limit = {
+						exists = yes
+						tag = BYZ
+					}
+					prestige = -3
+				}
+				clr_global_flag = anatolia_renamed
+		}
+	}
+
+	byzantine_armenia = {
+		potential = {
+			tag = BYZ
+			OR = {
+				owns = 890  #Van
+				owns = 893  #Diyarbakir
+				owns = 885  #Kars
+				owns = 1098 #Erivan
+			}
+			NOT = { has_global_flag = armenia_renamed }
+		}
+
+		allow = {
 			owns = 890  #Van
 			owns = 893  #Diyarbakir
 			owns = 885  #Kars
 			owns = 1098 #Erivan
+			owns = 1099 #Gyumri
+			war = no
 		}
-		NOT = { has_global_flag = armenia_renamed }
-	}
-	allow = {
-		owns = 890  #Van
-		owns = 893  #Diyarbakir
-		owns = 885  #Kars
-		owns = 1098 #Erivan
-		owns = 1099 #Gyumri
-		war = no
-	}
-	effect = {
-		890 = {
-			change_province_name = "Vasparkania"
-			state_scope = { change_region_name = "Armenia" }
-		}
-		891 = {
-			change_province_name = "Taron"
-		}
-		887 = {
-			change_province_name = "Theodosiopolis"
-		}
-		893 = {
-			change_province_name = "Amida"
-			state_scope = { change_region_name = "Mesopotamia" }
-		}
-		889 = {
-			change_province_name = "Melitene"
-		}
-		899 = {
-			change_province_name = "Edessa"
-		}
-		892 = {
-			change_province_name = "Gazarta"
-		}
-		885 = {
-			change_province_name = "Ani"
-			state_scope = { change_region_name = "Ani" }
-		}
-		1096 = {
-			change_province_name = "Lazike"
-		}
-		1098 = {
-			change_province_name = "Erebuni"
-			state_scope = { change_region_name = "Dwin"}
-		}
-		prestige = 2
-		set_global_flag = armenia_renamed
-		set_global_flag = armenia_renamed_tur
-	}
-}
 
-restore_armenia_not_TUR = {
-	potential = {
-		OR = {
-			tag = RUS
-			tag = ARM
-		}
-		owns = 1098 #Erivan
-		has_global_flag = armenia_renamed
-	}
-	allow = {
-		owns = 1098 #Erivan
-		war = no
-	}
-	effect = {
-		1098 = {
-			change_province_name = "Erivan"
-			state_scope = { change_region_name = "Armenia" }
-		}
-		random_country = {
-				limit = {
-					exists = yes
-					tag = BYZ
-				}
-				prestige = -3
+		effect = {
+			890 = {
+				change_province_name = "Vasparkania"
+				state_scope = { change_region_name = "Armenia" }
 			}
-			clr_global_flag = armenia_renamed
+			891 = {
+				change_province_name = "Taron"
+			}
+			887 = {
+				change_province_name = "Theodosiopolis"
+			}
+			893 = {
+				change_province_name = "Amida"
+				state_scope = { change_region_name = "Mesopotamia" }
+			}
+			889 = {
+				change_province_name = "Melitene"
+			}
+			899 = {
+				change_province_name = "Edessa"
+			}
+			892 = {
+				change_province_name = "Gazarta"
+			}
+			885 = {
+				change_province_name = "Ani"
+				state_scope = { change_region_name = "Ani" }
+			}
+			1096 = {
+				change_province_name = "Lazike"
+			}
+			1098 = {
+				change_province_name = "Erebuni"
+				state_scope = { change_region_name = "Dwin"}
+			}
+			prestige = 2
+			set_global_flag = armenia_renamed
+			set_global_flag = armenia_renamed_tur
+		}
 	}
-}
 
-restore_armenia_TUR = {
-	potential = {
-		tag = TUR
-		OR = {
+	restore_armenia_not_TUR = {
+		potential = {
+			OR = {
+				tag = RUS
+				tag = ARM
+			}
+			owns = 1098 #Erivan
+			has_global_flag = armenia_renamed
+		}
+
+		allow = {
+			owns = 1098 #Erivan
+			war = no
+		}
+
+		effect = {
+			1098 = {
+				change_province_name = "Erivan"
+				state_scope = { change_region_name = "Armenia" }
+			}
+			random_country = {
+					limit = {
+						exists = yes
+						tag = BYZ
+					}
+					prestige = -3
+				}
+				clr_global_flag = armenia_renamed
+		}
+	}
+
+	restore_armenia_TUR = {
+		potential = {
+			tag = TUR
+			OR = {
+				owns = 890  #Van
+				owns = 893  #Diyarbakir
+				owns = 885  #Kars
+			}
+			has_global_flag = armenia_renamed_tur
+		}
+
+		allow = {
 			owns = 890  #Van
 			owns = 893  #Diyarbakir
 			owns = 885  #Kars
+			war = no
 		}
-		has_global_flag = armenia_renamed_tur
-	}
-	allow = {
-		owns = 890  #Van
-		owns = 893  #Diyarbakir
-		owns = 885  #Kars
-		war = no
-	}
-	effect = {
-		890 = {
-			change_province_name = "Van"
-			state_scope = { change_region_name = "Van" }
-		}
-		891 = {
-			change_province_name = "Bitlis"
-		}
-		887 = {
-			change_province_name = "Erzurum"
-		}
-		893 = {
-			change_province_name = "Diyarbakir"
-			state_scope = { change_region_name = "Diyarbakir" }
-		}
-		889 = {
-			change_province_name = "Malatya"
-		}
-		899 = {
-			change_province_name = "Urfa"
-		}
-		892 = {
-			change_province_name = "Hakkari"
-		}
-		885 = {
-			change_province_name = "Kars"
-			state_scope = { change_region_name = "Kars" }
-		}
-		1096 = {
-			change_province_name = "Batum"
-		}
-		random_country = {
-				limit = {
-					exists = yes
-					tag = BYZ
-				}
-				prestige = -3
-			}
-			clr_global_flag = armenia_renamed_tur
-	}
-}
 
-byzantine_levant = {
-	potential = {
-		tag = BYZ
-		OR = {
+		effect = {
+			890 = {
+				change_province_name = "Van"
+				state_scope = { change_region_name = "Van" }
+			}
+			891 = {
+				change_province_name = "Bitlis"
+			}
+			887 = {
+				change_province_name = "Erzurum"
+			}
+			893 = {
+				change_province_name = "Diyarbakir"
+				state_scope = { change_region_name = "Diyarbakir" }
+			}
+			889 = {
+				change_province_name = "Malatya"
+			}
+			899 = {
+				change_province_name = "Urfa"
+			}
+			892 = {
+				change_province_name = "Hakkari"
+			}
+			885 = {
+				change_province_name = "Kars"
+				state_scope = { change_region_name = "Kars" }
+			}
+			1096 = {
+				change_province_name = "Batum"
+			}
+			random_country = {
+					limit = {
+						exists = yes
+						tag = BYZ
+					}
+					prestige = -3
+				}
+				clr_global_flag = armenia_renamed_tur
+		}
+	}
+
+	byzantine_levant = {
+		potential = {
+			tag = BYZ
+			OR = {
+				owns = 897 #Aleppo
+				owns = 903 #Homs
+				owns = 915 #Sidon
+				owns = 917 #Jerusalem
+				owns = 908 #Amman
+			}
+			NOT = { has_global_flag = levant_renamed }
+		}
+
+		allow = {
 			owns = 897 #Aleppo
 			owns = 903 #Homs
 			owns = 915 #Sidon
 			owns = 917 #Jerusalem
 			owns = 908 #Amman
+			war = no
 		}
-		NOT = { has_global_flag = levant_renamed }
-	}
-	allow = {
-		owns = 897 #Aleppo
-		owns = 903 #Homs
-		owns = 915 #Sidon
-		owns = 917 #Jerusalem
-		owns = 908 #Amman
-		war = no
-	}
-	effect = {
-		897 = {
-			change_province_name = "Berroea"
-			state_scope = { change_region_name = "Syria"}
-		}
-		900 = {
-			change_province_name = "Antiocheia"
-		}
-		905 = {
-			change_province_name = "Tripolis"
-		}
-		904 = {
-			change_province_name = "Epiphania"
-		}
-		901 = {
-			change_province_name = "Circession"
-		}
-		903 = {
-			state_scope = { change_region_name = "Damascus" }
-		}
-		915 = {
-			state_scope = { change_region_name = "Phoenice" }
-		}
-		914 = {
-			change_province_name = "Tyrus"
-		}
-		921 = {
-			change_province_name = "Herreketh"
-			state_scope = { change_region_name = "Palestina" }
-		}
-		918 = {
-			change_province_name = "Neapolis"
-		}
-		920 = {
-			change_province_name = "Ascalon"
-		}
-		917 = {
-			change_province_name = "Hierosolyma"
-		}
-		922 = {
-			change_province_name = "Kerak"
-			state_scope = { change_region_name = "Arabia"}
-		}
-		911 = {
-			change_province_name = "Bostra"
-		}
-		prestige = 2
-		set_global_flag = levant_renamed
-	}
-}
 
-restore_levant = {
-	potential = {
-		OR = {
-			tag = TUR
-			tag = EGY
+		effect = {
+			897 = {
+				change_province_name = "Berroea"
+				state_scope = { change_region_name = "Syria"}
+			}
+			900 = {
+				change_province_name = "Antiocheia"
+			}
+			905 = {
+				change_province_name = "Tripolis"
+			}
+			904 = {
+				change_province_name = "Epiphania"
+			}
+			901 = {
+				change_province_name = "Circession"
+			}
+			903 = {
+				state_scope = { change_region_name = "Damascus" }
+			}
+			915 = {
+				state_scope = { change_region_name = "Phoenice" }
+			}
+			914 = {
+				change_province_name = "Tyrus"
+			}
+			921 = {
+				change_province_name = "Herreketh"
+				state_scope = { change_region_name = "Palestina" }
+			}
+			918 = {
+				change_province_name = "Neapolis"
+			}
+			920 = {
+				change_province_name = "Ascalon"
+			}
+			917 = {
+				change_province_name = "Hierosolyma"
+			}
+			922 = {
+				change_province_name = "Kerak"
+				state_scope = { change_region_name = "Arabia"}
+			}
+			911 = {
+				change_province_name = "Bostra"
+			}
+			prestige = 2
+			set_global_flag = levant_renamed
 		}
-		OR = {
+	}
+
+	restore_levant = {
+		potential = {
+			OR = {
+				tag = TUR
+				tag = EGY
+			}
+			OR = {
+				owns = 897 #Aleppo
+				owns = 903 #Homs
+				owns = 915 #Sidon
+				owns = 917 #Jerusalem
+				owns = 908 #Amman
+			}
+			has_global_flag = byzantine_levant
+		}
+
+		allow = {
 			owns = 897 #Aleppo
 			owns = 903 #Homs
 			owns = 915 #Sidon
 			owns = 917 #Jerusalem
 			owns = 908 #Amman
+			war = no
 		}
-		has_global_flag = byzantine_levant
-	}
-	allow = {
-		owns = 897 #Aleppo
-		owns = 903 #Homs
-		owns = 915 #Sidon
-		owns = 917 #Jerusalem
-		owns = 908 #Amman
-		war = no
-	}
-	effect = {
-		897 = {
-			change_province_name = "Aleppo"
-			state_scope = { change_region_name = "Aleppo"}
-		}
-		900 = {
-			change_province_name = "Antioch"
-		}
-		905 = {
-			change_province_name = "Latakia"
-		}
-		904 = {
-			change_province_name = "Hama"
-		}
-		901 = {
-			change_province_name = "Dayr al-Zour"
-		}
-		903 = {
-			state_scope = { change_region_name = "Damascus" }
-		}
-		915 = {
-			state_scope = { change_province_name = "Lebanon" }
-		}
-		914 = {
-			change_province_name = "Askaleh"
-		}
-		921 = {
-			change_province_name = "Beersheba"
-			state_scope = { change_region_name = "Palestine" }
-		}
-		918 = {
-			change_province_name = "Nablus"
-		}
-		920 = {
-			change_province_name = "Gaza"
-		}
-		917 = {
-			change_province_name = "Jerusalem"
-		}
-		922 = {
-			change_province_name = "Akkaba"
-			state_scope = { change_region_name = "Jordan"}
-		}
-		911 = {
-			change_province_name = "Maan"
-		}
-		random_country = {
-				limit = {
-					exists = yes
-					tag = BYZ
-				}
-				prestige = -3
-			}
-			clr_global_flag = levant_renamed
-	}
-}
 
-byzantine_egypt = {
-	potential = {
-		tag = BYZ
-		OR = {
+		effect = {
+			897 = {
+				change_province_name = "Aleppo"
+				state_scope = { change_region_name = "Aleppo"}
+			}
+			900 = {
+				change_province_name = "Antioch"
+			}
+			905 = {
+				change_province_name = "Latakia"
+			}
+			904 = {
+				change_province_name = "Hama"
+			}
+			901 = {
+				change_province_name = "Dayr al-Zour"
+			}
+			903 = {
+				state_scope = { change_region_name = "Damascus" }
+			}
+			915 = {
+				state_scope = { change_province_name = "Lebanon" }
+			}
+			914 = {
+				change_province_name = "Askaleh"
+			}
+			921 = {
+				change_province_name = "Beersheba"
+				state_scope = { change_region_name = "Palestine" }
+			}
+			918 = {
+				change_province_name = "Nablus"
+			}
+			920 = {
+				change_province_name = "Gaza"
+			}
+			917 = {
+				change_province_name = "Jerusalem"
+			}
+			922 = {
+				change_province_name = "Akkaba"
+				state_scope = { change_region_name = "Jordan"}
+			}
+			911 = {
+				change_province_name = "Maan"
+			}
+			random_country = {
+					limit = {
+						exists = yes
+						tag = BYZ
+					}
+					prestige = -3
+				}
+				clr_global_flag = levant_renamed
+		}
+	}
+
+	byzantine_egypt = {
+		potential = {
+			tag = BYZ
+			OR = {
+				owns = 1755 #Suez
+				owns = 1751 #Alexandria
+				owns = 1753 #Sidi Barrani
+				owns = 1745 #Cairo
+				owns = 1762 #Asyut
+				owns = 1754 #Farafra
+				owns = 1771 #Marsa Alam
+			}
+			NOT = { has_global_flag = egypt_renamed }
+		}
+
+		allow = {
 			owns = 1755 #Suez
 			owns = 1751 #Alexandria
 			owns = 1753 #Sidi Barrani
@@ -1780,196 +2814,192 @@ byzantine_egypt = {
 			owns = 1762 #Asyut
 			owns = 1754 #Farafra
 			owns = 1771 #Marsa Alam
+			war = no
 		}
-		NOT = { has_global_flag = egypt_renamed }
-	}
-	allow = {
-		owns = 1755 #Suez
-		owns = 1751 #Alexandria
-		owns = 1753 #Sidi Barrani
-		owns = 1745 #Cairo
-		owns = 1762 #Asyut
-		owns = 1754 #Farafra
-		owns = 1771 #Marsa Alam
-		war = no
-	}
-	effect = {
-		1755 = {
-			change_province_name = "Klysma"
-			state_scope = { change_region_name = "Sinai" }
-		}
-		1756 = {
-			change_province_name = "Sinai"
-		}
-		1757 = {
-			change_province_name = "Pharan"
-		}
-		1751 = {
-			state_scope = { change_region_name = "Alexandria" }
-		}
-		1746 = {
-			change_province_name = "Damietta"
-		}
-		1747 = {
-			change_province_name = "Heliopolis"
-		}
-		1753 = {
-			change_province_name = "Antipyrgos"
-			state_scope = { change_region_name = "Oasis Mikra" }
-		}
-		1752 = {
-			change_province_name = "Paraitonion"
-		}
-		1754 = {
-			change_province_name = "Oasis Mikra"
-		}
-		1759 = {
-			change_province_name = "Crocodilopolis"
-		}
-		1745 = {
-			change_province_name = "Memphis"
-			state_scope = { change_region_name = "Arcadia" }
-		}
-		1748 = {
-			change_province_name = "Tamiathis"
-		}
-		1749 = {
-			change_province_name = "Augoustamnika"
-		}
-		1762 = {
-			change_province_name = "Lykoupolis"
-			state_scope = { change_region_name = "Aegyptus" }
-		}
-		1765 = {
-			change_province_name = "Arsinoe"
-		}
-		1764 = {
-			change_province_name = "Oxyrrhynchos"
-		}
-		1772 = {
-			change_province_name = "Myos Hormos"
-		}
-		1763 = {
-			change_province_name = "Herakleopolis"
-		}
-		2559 = {
-			change_province_name = "Abydos"
-		}
-		1760 = {
-			change_province_name = "Tchonemyris"
-			state_scope = { change_region_name = "Oasis Megale" }
-		}
-		1766 = {
-			change_province_name = "Syene"
-		}
-		1771 = {
-			change_province_name = "Berenike"
-			state_scope = { change_region_name = "Thebais"}
-		}
-		1769 = {
-			change_province_name = "Thebais"
-		}
-		1770 = {
-			change_province_name = "Kaine"
-		}
-		1768 = {
-			change_province_name = "Hierakonopolis"
-		}
-		prestige = 2
-		set_global_flag = egypt_renamed
-	}
-}
 
-byzantine_cyrenaica = {
-	potential = {
-		tag = BYZ
-		owns = 1735 #Benghazi
-		NOT = { has_global_flag = cyrenaica_renamed }
-	}
-	allow = {
-		owns = 1735 #Benghazi
-		war = no
-	}
-	effect = {
-		1735 = {
-			change_province_name = "Bernike"
-			state_scope = { change_region_name = "Kyrenaika" }
+		effect = {
+			1755 = {
+				change_province_name = "Klysma"
+				state_scope = { change_region_name = "Sinai" }
+			}
+			1756 = {
+				change_province_name = "Sinai"
+			}
+			1757 = {
+				change_province_name = "Pharan"
+			}
+			1751 = {
+				state_scope = { change_region_name = "Alexandria" }
+			}
+			1746 = {
+				change_province_name = "Damietta"
+			}
+			1747 = {
+				change_province_name = "Heliopolis"
+			}
+			1753 = {
+				change_province_name = "Antipyrgos"
+				state_scope = { change_region_name = "Oasis Mikra" }
+			}
+			1752 = {
+				change_province_name = "Paraitonion"
+			}
+			1754 = {
+				change_province_name = "Oasis Mikra"
+			}
+			1759 = {
+				change_province_name = "Crocodilopolis"
+			}
+			1745 = {
+				change_province_name = "Memphis"
+				state_scope = { change_region_name = "Arcadia" }
+			}
+			1748 = {
+				change_province_name = "Tamiathis"
+			}
+			1749 = {
+				change_province_name = "Augoustamnika"
+			}
+			1762 = {
+				change_province_name = "Lykoupolis"
+				state_scope = { change_region_name = "Aegyptus" }
+			}
+			1765 = {
+				change_province_name = "Arsinoe"
+			}
+			1764 = {
+				change_province_name = "Oxyrrhynchos"
+			}
+			1772 = {
+				change_province_name = "Myos Hormos"
+			}
+			1763 = {
+				change_province_name = "Herakleopolis"
+			}
+			2559 = {
+				change_province_name = "Abydos"
+			}
+			1760 = {
+				change_province_name = "Tchonemyris"
+				state_scope = { change_region_name = "Oasis Megale" }
+			}
+			1766 = {
+				change_province_name = "Syene"
+			}
+			1771 = {
+				change_province_name = "Berenike"
+				state_scope = { change_region_name = "Thebais"}
+			}
+			1769 = {
+				change_province_name = "Thebais"
+			}
+			1770 = {
+				change_province_name = "Kaine"
+			}
+			1768 = {
+				change_province_name = "Hierakonopolis"
+			}
+			prestige = 2
+			set_global_flag = egypt_renamed
 		}
-		1736 = {
-			change_province_name = "Kyrene"
-		}
-		1737 = {
-			change_province_name = "Marmarika"
-		}
-		prestige = 1
-		set_global_flag = cyrenaica_renamed
 	}
-}
 
-byzantine_tripolitania = {
-	potential = {
-		tag = BYZ
-		owns = 1731 #Tripoli
-		NOT = { has_global_flag = tripolitania_renamed }
-	}
-	allow = {
-		owns = 1731 #Tripoli
-		war = no
-	}
-	effect = {
-		1731 = {
-			change_province_name = "Tripolis"
-			state_scope = { change_region_name = Tripolitania }
+	byzantine_cyrenaica = {
+		potential = {
+			tag = BYZ
+			owns = 1735 #Benghazi
+			NOT = { has_global_flag = cyrenaica_renamed }
 		}
-		1733 = {
-			change_province_name = "Theubaktis"
-		}
-		1734 = {
-			change_province_name = "Syrtis"
-		}
-		1732 = {
-			change_province_name = "Pisida"
-		}
-		1744 = {
-			change_province_name = "Gigthis"
-		}
-		prestige = 1
-		set_global_flag = tripolitania_renamed
-	}
-}
 
-byzantine_tunis = {
-	potential = {
-		tag = BYZ
-		owns = 1726 #Bizerte
-		NOT = { has_global_flag = tunis_renamed }
+		allow = {
+			owns = 1735 #Benghazi
+			war = no
+		}
+
+		effect = {
+			1735 = {
+				change_province_name = "Bernike"
+				state_scope = { change_region_name = "Kyrenaika" }
+			}
+			1736 = {
+				change_province_name = "Kyrene"
+			}
+			1737 = {
+				change_province_name = "Marmarika"
+			}
+			prestige = 1
+			set_global_flag = cyrenaica_renamed
+		}
 	}
-	allow = {
-		owns = 1726 #Bizerte
-		war = no
+
+	byzantine_tripolitania = {
+		potential = {
+			tag = BYZ
+			owns = 1731 #Tripoli
+			NOT = { has_global_flag = tripolitania_renamed }
+		}
+
+		allow = {
+			owns = 1731 #Tripoli
+			war = no
+		}
+
+		effect = {
+			1731 = {
+				change_province_name = "Tripolis"
+				state_scope = { change_region_name = Tripolitania }
+			}
+			1733 = {
+				change_province_name = "Theubaktis"
+			}
+			1734 = {
+				change_province_name = "Syrtis"
+			}
+			1732 = {
+				change_province_name = "Pisida"
+			}
+			1744 = {
+				change_province_name = "Gigthis"
+			}
+			prestige = 1
+			set_global_flag = tripolitania_renamed
+		}
 	}
-	effect = {
-		1726 = {
-			change_province_name = "Hippon Diarrytos"
-			state_scope = { change_region_name = "Africa" }
+
+	byzantine_tunis = {
+		potential = {
+			tag = BYZ
+			owns = 1726 #Bizerte
+			NOT = { has_global_flag = tunis_renamed }
 		}
-		1725 = {
-			change_province_name = "Karchidon"
+
+		allow = {
+			owns = 1726 #Bizerte
+			war = no
 		}
-		1728 = {
-			change_province_name = "Iustinianopolis"
+
+		effect = {
+			1726 = {
+				change_province_name = "Hippon Diarrytos"
+				state_scope = { change_region_name = "Africa" }
+			}
+			1725 = {
+				change_province_name = "Karchidon"
+			}
+			1728 = {
+				change_province_name = "Iustinianopolis"
+			}
+			1730 = {
+				change_province_name = "Taparura"
+			}
+			1727 = {
+				change_province_name = "Xiros"
+			}
+			1729 = {
+				change_province_name = "Kapsa"
+			}
+			prestige = 1
+			set_global_flag = tunis_renamed
 		}
-		1730 = {
-			change_province_name = "Taparura"
-		}
-		1727 = {
-			change_province_name = "Xiros"
-		}
-		1729 = {
-			change_province_name = "Kapsa"
-		}
-		prestige = 1
-		set_global_flag = tunis_renamed
 	}
-}
 }

--- a/TGC/localisation/00_decisions-rename.csv
+++ b/TGC/localisation/00_decisions-rename.csv
@@ -19,6 +19,8 @@ banat_rename_rom_desc;Banat is rightfully $COUNTRY_ADJ$, and should use $COUNTRY
 banat_rename_rom_title;Rename Banat!;;;;;;;;;;;;;x
 banat_rename_ser_desc;Banat is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 banat_rename_ser_title;Rename Banat!;;;;;;;;;;;;;x
+banat_rename_tur_desc;Banat is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+banat_rename_tur_title;Rename Banat!;;;;;;;;;;;;;x
 Banat_romanian_title;Romanian names in Banat;;;;;;;;;;;;;x
 beneluxian_rename_friesland_desc;Friesland was and forever will be a Dutch province! Let us undo the damage the Germans have done!;;;;;;;;;;;;;x
 beneluxian_rename_friesland_title;Rename Friesland;;;;;;;;;;;;;x
@@ -34,6 +36,8 @@ bessarabia_rename_rom_desc;Bessarabia is rightfully $COUNTRY_ADJ$, and should us
 bessarabia_rename_rom_title;Rename Bessarabia!;;;;;;;;;;;;;x
 bessarabia_rename_rus_desc;Bessarabia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 bessarabia_rename_rus_title;Rename Bessarabia!;;;;;;;;;;;;;x
+bessarabia_rename_tur_desc;Bessarabia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+bessarabia_rename_tur_title;Rename Bessarabia!;;;;;;;;;;;;;x
 boer_south_africa_desc;"The British imperialists have finally been expelled from South Africa; it is a glorious day for our people.";;;;;;;;;;;;;x
 boer_south_africa_title;Süd Afrika;;;;;;;;;;;;;x
 bohemia_rename_aus_desc;Bohemia is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
@@ -69,6 +73,8 @@ bulgarian_rename_e_thrace_desc;Eastern Thrace was an artificial name created to 
 bulgarian_rename_e_thrace_title;Rename Eastern Thrace;;;;;;;;;;;;;x
 bulgarian_rename_n_macedonia_desc;Vardar Macedonia was an artificial name created to separate the $COUNTRY_ADJ$ people! The use of its name shall be discontinued!;;;;;;;;;;;;;x
 bulgarian_rename_n_macedonia_title;Rename Vardar Macedonia;;;;;;;;;;;;;x
+bulgarian_rename_dobrudja_desc;Dobrudja is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+bulgarian_rename_dobrudja_title;Rename Dobrudja;;;;;;;;;;;;;x
 burgenland_rename_desc;Burgenland is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 burgenland_rename_title;Rename Burgenland;;;;;;;;;;;;;x
 byzantine_anatolia_desc;We should restore the proper names of Anatolian provinces.;;;;;;;;;;;;;x
@@ -97,10 +103,12 @@ car_ukr_rename_rus_desc;Slovakia is rightfully $COUNTRY_ADJ$, and should use $CO
 car_ukr_rename_rus_title;Rename Carpatho-Ukraine!;;;;;;;;;;;;;x
 car_ukr_rename_ukr_desc;Slovakia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 car_ukr_rename_ukr_title;Rename Carpatho-Ukraine!;;;;;;;;;;;;;x
-central_hungary_rename_aus_desc;Central Hungary rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
+central_hungary_rename_aus_desc;Central Hungary is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
 central_hungary_rename_aus_title;Rename Central Hungary;;;;;;;;;;;;;x
 central_hungary_rename_hun_desc;Central Hungary is rightfully $COUNTRY_ADJ$, and should use Hungarian names.;;;;;;;;;;;;;x
 central_hungary_rename_hun_title;Rename Central Hungary;;;;;;;;;;;;;x
+central_hungary_rename_tur_desc;Central Hungary is rightfully $COUNTRY_ADJ$, and should use Turkish names.;;;;;;;;;;;;;x
+central_hungary_rename_tur_title;Rename Central Hungary;;;;;;;;;;;;;x
 centralize_kurdish_states_desc;Administration in the border with Persia has long been rudimentary, lacking a central authority and being ruled by Kurdish tribes’ leaders in the name of the Caliph. It’s high time we end that and establish a central, organized government lead by a governor appointed by our $MONARCHTITLE$ himself. The Kurds will obviously not approve of this, and we will have to do this transition by force, but the Ottoman policy of removing old hereditary rulers and replacing them with men appointed and controlled by $CAPITAL$ must continue.;;;;;;;;;;;;;x
 centralize_kurdish_states_title;Centralize the Kurdish States;;;;;;;;;;;;;x
 chinese_outer_manchuria_desc;For too long outsiders dominated Guanwai. And now we expelled the barbarians. They called these Chinese lands by foreign names for too long, replacing them all and using their barbaric language everywhere. We should restore the proper names for this region and for these provinces as soon as possible.;;;;;;;;;;;;;x
@@ -138,6 +146,8 @@ croatia_rename_cro_desc;Croatia rightfully $COUNTRY_ADJ$, and should use Croat n
 croatia_rename_cro_title;Rename Croatia;;;;;;;;;;;;;x
 croatia_rename_hun_desc;Croatia is rightfully $COUNTRY_ADJ$, and should use Hungarian names.;;;;;;;;;;;;;x
 croatia_rename_hun_title;Rename Croatia;;;;;;;;;;;;;x
+croatia_rename_tur_desc;Croatia is rightfully $COUNTRY_ADJ$, and should use Turkish names.;;;;;;;;;;;;;x
+croatia_rename_tur_title;Rename Croatia;;;;;;;;;;;;;x
 croatian_compromise_desc;Inspired by the Austro-Hungarian Compromise enacted the year before, the Croatian-Hungarian Settlement acknowledged the long-standing autonomy of Croatia within Hungary. It allowed the formation of a Croatian Parliament and gave seats to Croatian MPs in Budapest. With this compromise, we recognise Croatians as full citizens of our state.;;;;;;;;;;;;;x
 croatian_compromise_title;The Croatian Compromise;;;;;;;;;;;;;x
 czech_bohemia_desc;Now that Bohemia has gained its freedom, proper Czech names can be restored to the land.;;;;;;;;;;;;;x
@@ -163,20 +173,6 @@ danzig_imperial_shipyard_desc;The Königliche Werft Danzig (Eventually renamed Ka
 Danzig_polish_title;Polish names in Gdansk;;;;;;;;;;;;;x
 degermanize_bessarabien_desc;Bessarabia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 degermanize_bessarabien_title;Rename Bessarabia!;;;;;;;;;;;;;x
-degermanize_brêst_desc;Brêst is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_brêst_title;Rename Brêst;;;;;;;;;;;;;x
-degermanize_kyiv_desc;Kyiv is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_kyiv_title;Rename Kyiv;;;;;;;;;;;;;x
-degermanize_minsk_desc;Minsk is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_minsk_title;Rename Minsk;;;;;;;;;;;;;x
-degermanize_pinsk_desc;Pinsk is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_pinsk_title;Rename Pinsk;;;;;;;;;;;;;x
-degermanize_rename_volyn_desc;Volyn is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_rename_volyn_title;Rename Volyn;;;;;;;;;;;;;x
-degermanize_transnistria_desc;Transnistria is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_transnistria_title;Rename Transnistria;;;;;;;;;;;;;x
-degermanize_yekaterinoslav_desc;Yekaterinoslav is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-degermanize_yekaterinoslav_title;Rename Yekaterinoslav;;;;;;;;;;;;;x
 dutch_wallonia_desc;During the Belgian independence, the Walloons renamed the towns, natural features, roads and villages in their language. With the return of the rightful $COUNTRY_ADJ$ rule in the region, there would be nothing more natural than restoring the proper names.;;;;;;;;;;;;;x
 dutch_wallonia_title;$COUNTRY_ADJ$ Wallonia;;;;;;;;;;;;;x
 east_galicia_rename_german_desc;East Galicia is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
@@ -202,6 +198,8 @@ fatherland_altar_desc;There’s a proposal in the cabinet to build an Altar of the
 fatherland_altar_title;Build an Altar for the Fatherland;;;;;;;;;;;;;x
 finland_rename_fin_desc;Finland is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 finland_rename_fin_title;Rename Finland!;;;;;;;;;;;;;x
+finnish_rename_ingermanland_desc;With our success against the Russians we manged to retake once Finnish land, in order to restore our rule, let us rename the cities in this region.;;;;;;;;;;;;;x
+finnish_rename_ingermanland_title;Rename Ingria;;;;;;;;;;;;;x
 finland_rename_rus_desc;Finland is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 finland_rename_rus_title;Rename Finland!;;;;;;;;;;;;;x
 finland_rename_swe_desc;Finland is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
@@ -229,6 +227,8 @@ french_rename_artesia_desc;With our victory against the Germans, we have managed
 french_rename_artesia_title;Rename Artesia;;;;;;;;;;;;;x
 french_renamed_savoy_aosta_desc;Savoy rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 french_renamed_savoy_aosta_title;Rename Savoy;;;;;;;;;;;;;x
+french_rename_zeeland_desc;With our great victory we have pushed our borders all the way to the natural borders of France, the river Rhine. Let us rename the region accordingly.;;;;;;;;;;;;;x
+french_rename_zeeland_title;Rename Zeeland;;;;;;;;;;;;;x
 galicia_rename_german_desc;East Galicia is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
 galicia_rename_german_title;Rename Galicia-Lodomeria;;;;;;;;;;;;;x
 german_allenstein_desc;Now that Allenstein has been recovered, proper German names can be restored to the land.;;;;;;;;;;;;;x
@@ -245,14 +245,18 @@ german_posen_desc;Now that Posen has been recovered, proper German names can be 
 german_posen_title;German Posen;;;;;;;;;;;;;x
 german_rename_artoris_desc;With our victory against the French, we have managed to retake what was once Dutch land. Let us restore order to these provinces by renaming the cities.;;;;;;;;;;;;;x
 german_rename_artoris_title;Rename Artesia;;;;;;;;;;;;;x
+german_rename_azov_desc;Azov is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_azov_title;Rename Azov;;;;;;;;;;;;;x
 german_rename_bessarabien_desc;Bessarabia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 german_rename_bessarabien_title;Rename Bessarabia;;;;;;;;;;;;;x
 german_rename_bosnia_desc;Bosnia rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 german_rename_bosnia_title;Rename Bosnia!;;;;;;;;;;;;;x
 german_rename_brandenburg_desc;Brandenburg was and always will be German! Therefore, we will rename our cities in this area!;;;;;;;;;;;;;x
 german_rename_brandenburg_title;Restoring Brandenburg;;;;;;;;;;;;;x
-german_rename_brêst_desc;Brêst is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-german_rename_brêst_title;Rename Brêst;;;;;;;;;;;;;x
+german_rename_brest_desc;Brest is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_brest_title;Rename Brest;;;;;;;;;;;;;x
+german_rename_crimea_desc;Crimea is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_crimea_title;Rename Crimea;;;;;;;;;;;;;x
 german_rename_eastprussia_desc;The Poles dared to rename East Prussia, yet the former capital of the mighty Prussia shall remain German!;;;;;;;;;;;;;x
 german_rename_eastprussia_title;Rename East Prussia!;;;;;;;;;;;;;x
 german_rename_friesland_desc;Friesland was always a distinct, yet very Germanic, province of the Netherlands. Let us now fully incorporate it into the Reich.;;;;;;;;;;;;;x
@@ -261,6 +265,10 @@ german_rename_holland_desc;With our great victory we have managed to fully acqui
 german_rename_holland_title;Rename Holland;;;;;;;;;;;;;x
 german_rename_jylland_desc;The Danes were no match for our military might, let us now rename it to show who owns Jylland now!;;;;;;;;;;;;;x
 german_rename_jylland_title;Rename Jylland;;;;;;;;;;;;;x
+german_rename_kharkiv_desc;Kharkiv is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_kharkiv_title;Rename Kharkiv;;;;;;;;;;;;;x
+german_rename_kuban_desc;Kuban is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_kuban_title;Rename Kuban;;;;;;;;;;;;;x
 german_rename_kyiv_desc;Kyiv is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 german_rename_kyiv_title;Rename Kyiv;;;;;;;;;;;;;x
 german_rename_memel_desc;Memel is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
@@ -291,6 +299,8 @@ german_rename_wallonien_desc;Though being very French, Wallonia was an important
 german_rename_wallonien_title;Rename Wallonia;;;;;;;;;;;;;x
 german_rename_yekaterinoslav_desc;Yekaterinoslav is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 german_rename_yekaterinoslav_title;Rename Yekaterinoslav;;;;;;;;;;;;;x
+german_rename_zaporozhia_desc;Zaporozhia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+german_rename_zaporozhia_title;Rename Zaporozhia;;;;;;;;;;;;;x
 german_rename_zeeland_desc;With our great victory we have managed to fully acquire a part the homeland of the Dutch, Zeeland. Let us now incorporate these Germanic people too!;;;;;;;;;;;;;x
 german_rename_zeeland_title;Rename Zeeland;;;;;;;;;;;;;x
 german_tyrol_desc;As everyone knows, the natural border of Germany is the Adige or Etsch. South Tyrol always was German land, the people German, and the cities had German names. Considering the part of the Trentino… well, we will find some fitting names.;;;;;;;;;;;;;x
@@ -313,12 +323,16 @@ greek_n_macedonia_desc;Greeks have inhabited Macedonia since antiquity. With the
 greek_n_macedonia_title;Greek Northern Macedonia;;;;;;;;;;;;;x
 greek_nicaea_desc;Greeks have inhabited Nicaea since antiquity. With the region now firmly under our control, proper Greek names can be restored to these lands.;;;;;;;;;;;;;x
 greek_nicaea_title;Greek Nicaea;;;;;;;;;;;;;x
+greek_rename_aegean_islands_desc;The Aegean Islands are rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+greek_rename_aegean_islands_title;Rename the Aegean Islands;;;;;;;;;;;;;x
 greek_rename_athos_desc;The Holy Mountain rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 greek_rename_athos_title;Rename the Holy Mountain!;;;;;;;;;;;;;x
 greek_rename_aydin_desc;Ionia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 greek_rename_aydin_title;Rename Ionia;;;;;;;;;;;;;x
 greek_rename_c_macedonia_desc;Central Macedonia rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 greek_rename_c_macedonia_title;Rename Central Macedonia!;;;;;;;;;;;;;x
+greek_rename_cyprus_desc;Cyprus is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+greek_rename_cyprus_title;Rename Cyprus;;;;;;;;;;;;;x
 greek_rename_e_macedonia_desc;Eastern is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 greek_rename_e_macedonia_title;Rename Eastern Macedonia;;;;;;;;;;;;;x
 greek_rename_e_thrace_desc;Eastern Thrace is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
@@ -327,16 +341,22 @@ greek_rename_epirus_desc;Epirus is rightfully $COUNTRY_ADJ$, and should use $COU
 greek_rename_epirus_title;Rename Epirus!;;;;;;;;;;;;;x
 greek_rename_hudavendigar_desc;Vithinia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 greek_rename_hudavendigar_title;Rename Vithinia;;;;;;;;;;;;;x
+greek_rename_ionian_islands_desc;The Ionian Islands are rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+greek_rename_ionian_islands_title;Rename the Ionian Islands;;;;;;;;;;;;;x
 greek_rename_kastamonu_desc;Paphlagonia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 greek_rename_kastamonu_title;Rename Paphlagonia;;;;;;;;;;;;;x
 greek_rename_konya_desc;Pisidia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 greek_rename_konya_title;Rename Pisidia;;;;;;;;;;;;;x
 greek_rename_n_macedonia_desc;Paionia was an artificial name created to separate the $COUNTRY_ADJ$ people! The use of its name shall be discontinued!;;;;;;;;;;;;;x
 greek_rename_n_macedonia_title;Rename Paionia;;;;;;;;;;;;;x
+greek_rename_peloponnese_desc;Peloponnese is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+greek_rename_peloponnese_title;Rename Peloponnese;;;;;;;;;;;;;x
 greek_rename_rumelia_desc;Northern Thrace is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 greek_rename_rumelia_title;Rename Northern Thrace;;;;;;;;;;;;;x
 greek_rename_s_macedonia_desc;Southern Macedonia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 greek_rename_s_macedonia_title;Rename Southern Macedonia;;;;;;;;;;;;;x
+greek_rename_thessalia_desc;Thessalia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+greek_rename_thessalia_title;Rename Thessalia;;;;;;;;;;;;;x
 greek_rumelia_desc;Greeks have inhabited Northern Thrace since antiquity. With the region now firmly under our control, proper Greek names can be restored to these lands.;;;;;;;;;;;;;x
 greek_rumelia_title;Greek Northern Thrace;;;;;;;;;;;;;x
 Greek_Sicily_desc;Now that Sicily is in our hands, we must re-establish the name of the glorious Hellenic cities west of Hellas!;;;;;;;;;;;;;x
@@ -372,6 +392,8 @@ istria_rename_yug_desc;Istria is rightfully $COUNTRY_ADJ$, and should use Croati
 istria_rename_yug_title;Rename Istria;;;;;;;;;;;;;x
 italian_dalmatia_desc;We should rename the cities at the dalmatian coast and give them Italian names. They sound much better and reflect the glory of our nation.;;;;;;;;;;;;;x
 italian_dalmatia_title;Reintroduce Italian Names in Dalmatia!;;;;;;;;;;;;;x
+italian_rename_ionian_islands_desc;The Ionian Islands are rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+italian_rename_ionian_islands_title;Rename the Ionian Islands;;;;;;;;;;;;;x
 italian_lombardy_desc;Since Lombardia has been restored to its rightful place within our great nation, we should probably revert the street signs back.;;;;;;;;;;;;;x
 italian_lombardy_title;Restore Lombardia!;;;;;;;;;;;;;x
 italian_renamed_savoy_aosta_desc;Savoy rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
@@ -473,10 +495,14 @@ northern_transylvania_rename_hun_desc;Northern-Transylvania is rightfully $COUNT
 northern_transylvania_rename_hun_title;Rename Northern-Transylvania;;;;;;;;;;;;;x
 northern_transylvania_rename_rom_desc;Northern-Transylvania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 northern_transylvania_rename_rom_title;Rename Northern-Transylvania;;;;;;;;;;;;;x
+northern_transylvania_rename_tur_desc;Northern-Transylvania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+northern_transylvania_rename_tur_title;Rename Northern-Transylvania;;;;;;;;;;;;;x
 orange_rename_desc;The Orange River Colony is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 orange_rename_title;Rename the Orange River Colony!;;;;;;;;;;;;;x
 petrograd_renaming_act_desc;The war with the Germans rage on and our government has a proposal to rename the city of Saint Petersburg to Petrograd, meaning ‘Peter’s City’, to remove the German words Sankt and Burg.;;;;;;;;;;;;;x
 petrograd_renaming_act_title;Renaming Saint Petersburg;;;;;;;;;;;;;x
+petrograd_renaming_act2_desc;With our victory against the Russians, we are free to impose our will on them. They renamed their capital to spite us - it is time the old, proper name is restored.;;;;;;;;;;;;;x
+petrograd_renaming_act2_title;Renaming Saint Petersburg;;;;;;;;;;;;;x
 podlachia_rename_german_desc;Podlachia is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
 podlachia_rename_german_title;Rename Podlachia;;;;;;;;;;;;;x
 podlachia_rename_polish_desc;Podlachia is rightfully $COUNTRY_ADJ$, and should use Polish names.;;;;;;;;;;;;;x
@@ -493,8 +519,8 @@ poldachia_rename_russian_desc;Poldachia is rightfully $COUNTRY_ADJ$, and should 
 poldachia_rename_russian_title;Rename Poldachia!;;;;;;;;;;;;;x
 polish_bielsko_desc;Now that Bielsko has gained its freedom, proper Polish names can be restored to the land.;;;;;;;;;;;;;x
 polish_bielsko_title;Polish Bielsko;;;;;;;;;;;;;x
-polish_brêst_desc;Brêst is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-polish_brêst_title;Polish Brêst;;;;;;;;;;;;;x
+polish_brest_desc;Brest is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+polish_brest_title;Polish Brest;;;;;;;;;;;;;x
 polish_cieszyn_desc;Now that Cieszyn has gained its freedom, proper Polish names can be restored to the land.;;;;;;;;;;;;;x
 polish_cieszyn_title;Polish Cieszyn;;;;;;;;;;;;;x
 polish_gdansk_desc;Now that Gdansk has gained its freedom, proper Polish names can be restored to the land.;;;;;;;;;;;;;x
@@ -653,8 +679,40 @@ romanian_north_transylvania_desc;Now that North Transylvania has gained its free
 romanian_north_transylvania_title;Romanian North Transylvania;;;;;;;;;;;;;x
 romanian_south_transylvania_desc;Now that South Transylvania has gained its freedom, proper Romanian names can be restored to the land.;;;;;;;;;;;;;x
 romanian_south_transylvania_title;Romanian South Transylvania;;;;;;;;;;;;;x
+romanian_rename_wallachia_desc;Wallachia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+romanian_rename_wallachia_title;Rename Wallachia;;;;;;;;;;;;;x
+romanian_rename_moldavia_desc;Moldavia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+romanian_rename_moldavia_title;Rename Moldavia;;;;;;;;;;;;;x
+romanian_rename_dobrudja_desc;Dobrudja is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+romanian_rename_dobrudja_title;Rename Dobrudja;;;;;;;;;;;;;x
+romanian_transnistria_desc;Transnistria is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+romanian_transnistria_title;Rename Transnistria;;;;;;;;;;;;;x
+russian_azov_desc;Azov is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_azov_title;Rename Azov;;;;;;;;;;;;;x
+russian_brest_desc;Brest is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_brest_title;Rename Brest;;;;;;;;;;;;;x
+russian_crimea_desc;Crimea is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_crimea_title;Rename Crimea;;;;;;;;;;;;;x
+russian_kharkiv_desc;Kharkiv is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_kharkiv_title;Rename Kharkiv;;;;;;;;;;;;;x
+russian_kuban_desc;Kuban is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_kuban_title;Rename Kuban;;;;;;;;;;;;;x
+russian_kyiv_desc;Kyiv is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_kyiv_title;Rename Kyiv;;;;;;;;;;;;;x
+russian_minsk_desc;Minsk is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_minsk_title;Rename Minsk;;;;;;;;;;;;;x
 russian_orsha_desc;Orsha is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 russian_orsha_title;Restore Orsha;;;;;;;;;;;;;x
+russian_pinsk_desc;Pinsk is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_pinsk_title;Rename Pinsk;;;;;;;;;;;;;x
+russian_volyn_desc;Volyn is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_volyn_title;Rename Volyn;;;;;;;;;;;;;x
+russian_transnistria_desc;Transnistria is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_transnistria_title;Rename Transnistria;;;;;;;;;;;;;x
+russian_yekaterinoslav_desc;Yekaterinoslav is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_yekaterinoslav_title;Rename Yekaterinoslav;;;;;;;;;;;;;x
+russian_zaporozhia_desc;Zaporozhia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+russian_zaporozhia_title;Rename Zaporozhia;;;;;;;;;;;;;x
 russian_rename_eastprussia_desc;East Prussia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 russian_rename_eastprussia_title;Rename East Prussia!;;;;;;;;;;;;;x
 russian_rename_ingermanland_desc;The Scandinavians dared to rename our cities, now that we have driven them out once again, let us restoke the Russian names to our cities.;;;;;;;;;;;;;x
@@ -689,10 +747,14 @@ scandinavian_rename_sjaelland_desc;Despite all the odds, we have managed to beat
 scandinavian_rename_sjaelland_title;Rename Sjaelland;;;;;;;;;;;;;x
 serbian_rename_albania_desc;Albania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 serbian_rename_albania_title;Rename Albania;;;;;;;;;;;;;x
+serbian_rename_athos_desc;Athos rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+serbian_rename_athos_title;Rename Athos!;;;;;;;;;;;;;x
 serbian_rename_cro_cores_desc;Krajina is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 serbian_rename_cro_cores_title;Rename Krajina;;;;;;;;;;;;;x
 serbian_rename_cro_desc;Croatia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 serbian_rename_cro_title;Rename Croatia;;;;;;;;;;;;;x
+serbian_rename_c_macedonia_desc;Central Macedonia rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+serbian_rename_c_macedonia_title;Rename Central Macedonia!;;;;;;;;;;;;;x
 serbian_rename_n_macedonia_desc;Vardar Macedonia was an artificial name created to separate the $COUNTRY_ADJ$ people! The use of its name shall be discontinued!;;;;;;;;;;;;;x
 serbian_rename_n_macedonia_title;Rename Vardar Macedonia;;;;;;;;;;;;;x
 serbian_rename_s_macedonia_desc;Southern Macedonia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
@@ -754,7 +816,9 @@ southern_transylvania_rename_aus_title;Rename Southern-Transylvania;;;;;;;;;;;;;
 southern_transylvania_rename_hun_desc;Southern-Transylvania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 southern_transylvania_rename_hun_title;Rename Southern-Transylvania;;;;;;;;;;;;;x
 southern_transylvania_rename_rom_desc;Southern-Transylvania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
-southern_transylvania_rename_rom_title;Rename Northern-Transylvania;;;;;;;;;;;;;x
+southern_transylvania_rename_rom_title;Rename Southern-Transylvania;;;;;;;;;;;;;x
+southern_transylvania_rename_tur_desc;Southern-Transylvania is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+southern_transylvania_rename_tur_title;Rename Southern-Transylvania;;;;;;;;;;;;;x
 soviet_cities_desc;After the Russian Revolution, the ruling Bolsheviks renamed several Russian cities, notably to recognize early leaders and intellectuals in the Communist Party or simply to remove names tied to the old Tsarist era.;;;;;;;;;;;;;x
 soviet_cities_title;Proclaim Soviet Cities;;;;;;;;;;;;;x
 st_barths_question_desc;The island of Saint Barthélemy had belonged to France until 1784, when it was transferred to Sweden in return for trade privileges in Gothenburg. However, the island proved expensive to maintain. We can push for an agreement and a referendum on the island status and future, but there’s always the chance that they might cede the island to another power to avoid conflict with us. Even if we lost the referendum, we will still be able to claim the island.;;;;;;;;;;;;;x
@@ -782,6 +846,10 @@ taiwan_administration_desc;Japan now controls Formosa, and our modern administra
 taiwan_administration_title;Japanese Formosa;;;;;;;;;;;;;x
 tasmania_penal_colony_desc;In 1803 the island south of Australia was colonized by the British as a penal colony with the name Van Diemen’s Land, and became part of the British colony of New South Wales. Male convicts served their sentences as assigned labour to free settlers or in gangs assigned to public works. Only the most difficult convicts (mostly re-offenders) were sent to the Tasman Peninsula prison known as Port Arthur. Female convicts were assigned as servants in free settler households or sent to a female factory (women’s workhouse prison). There were five female factories in Van Diemen’s Land. Convicts completing their sentences or earning their ticket-of-leave often promptly left Van Diemen’s Land. Many settled in the new free colony of Victoria, to the dismay of the free settlers in towns such as Melbourne.\n\nWe can abolish the penal colony and convert the island to a regular colony. Changing the name to Tasmania from Van Diemen’s Land should help our government to clear a little bit of the stigma that the island has.;;;;;;;;;;;;;x
 tasmania_penal_colony_title;Van Diemen’s Land Penal Colony;;;;;;;;;;;;;x
+tatar_crimea_desc;Crimea is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+tatar_crimea_title;Rename Crimea;;;;;;;;;;;;;x
+tatar_zaporozhia_desc;Zaporozhia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+tatar_zaporozhia_title;Rename Zaporozhia;;;;;;;;;;;;;x
 transdanubia_rename_aus_desc;Transdanubia is rightfully $COUNTRY_ADJ$, and should use German names.;;;;;;;;;;;;;x
 transdanubia_rename_aus_title;Rename Transdanubia;;;;;;;;;;;;;x
 transdanubia_rename_hun_desc;Transdanubia is rightfully $COUNTRY_ADJ$, and should use Hungarian names.;;;;;;;;;;;;;x
@@ -802,6 +870,8 @@ turk_rename_s_serbia_desc;Southern Serbia rightfully belongs to $COUNTRY$, and s
 turk_rename_s_serbia_title;Rename Southern Serbia!;;;;;;;;;;;;;x
 turkification_desc;It has been decided that provinces, districts, towns, villages, mountains, and rivers, which are named in languages belonging to non-Muslim nations such as Armenian, Greek or Bulgarian, will be renamed into Turkish. In order to benefit from this suitable moment, this aim should be achieved in due course. Ordinance of Enver Pasa \n\n If we want to be the owners of our country, then we should turn even the name of the smallest village into Turkish and not leave its Armenian, Greek or Arabic variants.;;;;;;;;;;;;;x
 turkification_title;Turkification;;;;;;;;;;;;;x
+turkish_rename_aegean_islands_desc;The Aegean Islands are rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_aegean_islands_title;Rename the Aegean Islands;;;;;;;;;;;;;x
 turkish_rename_athos_desc;Athos rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 turkish_rename_athos_title;Rename Athos!;;;;;;;;;;;;;x
 turkish_rename_aydin_desc;Aydin is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
@@ -810,6 +880,10 @@ turkish_rename_bulgaria_desc;Northern Bulgaria rightfully belongs to $COUNTRY$, 
 turkish_rename_bulgaria_title;Rename Northern Bulgaria!;;;;;;;;;;;;;x
 turkish_rename_c_macedonia_desc;Central Macedonia rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 turkish_rename_c_macedonia_title;Rename Central Macedonia!;;;;;;;;;;;;;x
+turkish_rename_cyprus_desc;Cyprus is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_cyprus_title;Rename Cyprus;;;;;;;;;;;;;x
+turkish_crimea_desc;Crimea is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+turkish_crimea_title;Rename Crimea;;;;;;;;;;;;;x
 turkish_rename_debar_desc;Debar rightfully belongs to $COUNTRY$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 turkish_rename_debar_title;Rename Debar!;;;;;;;;;;;;;x
 turkish_rename_e_macedonia_desc;Eastern Macedonia was an artificial name created to separate the $COUNTRY_ADJ$ people! The use of its name shall be discontinued!;;;;;;;;;;;;;x
@@ -820,18 +894,32 @@ turkish_rename_epirus_desc;Epiri is rightfully Turkish, and should use Turkish n
 turkish_rename_epirus_title;Rename Epiri!;;;;;;;;;;;;;x
 turkish_rename_hudavendigar_desc;Hudavendigar is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 turkish_rename_hudavendigar_title;Rename Hudavendigar;;;;;;;;;;;;;x
+turkish_rename_ionian_islands_desc;The Ionian Islands are rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_ionian_islands_title;Rename the Ionian Islands;;;;;;;;;;;;;x
 turkish_rename_kastamonu_desc;Kastamonu is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 turkish_rename_kastamonu_title;Rename Kastamonu;;;;;;;;;;;;;x
 turkish_rename_konya_desc;Konya is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 turkish_rename_konya_title;Rename Konya;;;;;;;;;;;;;x
 turkish_rename_n_macedonia_desc;Northern Macedonia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 turkish_rename_n_macedonia_title;Rename Northern Macedonia;;;;;;;;;;;;;x
+turkish_rename_peloponnese_desc;Peloponnese is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_peloponnese_title;Rename the Peloponnese;;;;;;;;;;;;;x
 turkish_rename_rumelia_desc;Eastern Rumelia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
 turkish_rename_rumelia_title;Rename Eastern Rumelia;;;;;;;;;;;;;x
 turkish_rename_s_macedonia_desc;Southern Macedonia is rightfully Turkish, and should use Turkish names.;;;;;;;;;;;;;x
 turkish_rename_s_macedonia_title;Rename Southern Macedonia;;;;;;;;;;;;;x
+turkish_rename_thessalia_desc;Thessalia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+turkish_rename_thessalia_title;Rename Thessalia;;;;;;;;;;;;;x
 turkish_rename_trabzon_desc;Trebizond is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
 turkish_rename_trabzon_title;Rename Trebizond;;;;;;;;;;;;;x
+turkish_rename_wallachia_desc;Wallachia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_wallachia_title;Rename Wallachia;;;;;;;;;;;;;x
+turkish_rename_moldavia_desc;Moldavia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_moldavia_title;Rename Moldavia;;;;;;;;;;;;;x
+turkish_rename_dobrudja_desc;Dobrudja is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names!;;;;;;;;;;;;;x
+turkish_rename_dobrudja_title;Rename Dobrudja;;;;;;;;;;;;;x
+turkish_zaporozhia_desc;Zaporozhia is rightfully $COUNTRY_ADJ$, and should use $COUNTRY_ADJ$ names.;;;;;;;;;;;;;x
+turkish_zaporozhia_title;Rename Zaporozhia;;;;;;;;;;;;;x
 UBD_germans_accepted_desc;Baltic Germans have lived in the Baltic States for a long time and while they were once one of the dominant forces in the region, they no longer hold any power in the government or society. As the Baltic States are under our protection and control, we should reinstall the German nobility to serve us better.;;;;;;;;;;;;;x
 UBD_germans_accepted_title;Restore the Baltic German Nobility;;;;;;;;;;;;;x
 venetian_dalmatia_desc;For centuries the Dalmatian coast was a territory of the Republic of Venice. The Napoleonic wars saw the end of the Republic, and Dalmatia was transferred to Austria at the Vienna Congress, but the region’s Italian population remains. We could credibly lay claim to the coast and tighten our grip on the Adriatic.;;;;;;;;;;;;;x

--- a/TGC/localisation/00_map-provinces.csv
+++ b/TGC/localisation/00_map-provinces.csv
@@ -853,9 +853,9 @@ PROV851;Gümülcine;;;;;;;;;;;;;x
 PROV852;Avlonya;;;;;;;;;;;;;x
 PROV853;Ergiri Kasri;;;;;;;;;;;;;x
 PROV854;Malta;;;;;;;;;;;;;x
-PROV855;Lefkoša;;;;;;;;;;;;;x
+PROV855;Lefkosa;;;;;;;;;;;;;x
 PROV856;Leymosun;;;;;;;;;;;;;x
-PROV857;Magusa;;;;;;;;;;;;;x
+PROV857;Gazimagusa;;;;;;;;;;;;;x
 PROV858;Kirklareli;;;;;;;;;;;;;x
 PROV859;Gelibolu;;;;;;;;;;;;;x
 PROV860;Kostantiniyye;;;;;;;;;;;;;x
@@ -938,6 +938,7 @@ PROV936;Grodno;;;;;;;;;;;;;x
 PROV937;Pruzhany;;;;;;;;;;;;;x
 PROV938;Lida;;;;;;;;;;;;;x
 PROV939;Pinsk;;;;;;;;;;;;;x
+PROV940;Brest-Litovsk;;;;;;;;;;;;;x
 PROV941;Slutsk;;;;;;;;;;;;;x
 PROV942;Mozyr;;;;;;;;;;;;;x
 PROV943;Smolensk;;;;;;;;;;;;;x
@@ -971,8 +972,8 @@ PROV970;Nikolaev;;;;;;;;;;;;;x
 PROV971;Yelisavetgrad;;;;;;;;;;;;;x
 PROV972;Yekaterinoslav;;;;;;;;;;;;;x
 PROV973;Melitopol;;;;;;;;;;;;;x
-PROV974;Bakhmut;;;;;;;;;;;;;x
-PROV975;Slavjansk;;;;;;;;;;;;;x
+PROV974;Yuzovka;;;;;;;;;;;;;x
+PROV975;Berdyansk;;;;;;;;;;;;;x
 PROV976;Mariupol;;;;;;;;;;;;;x
 PROV977;Kursk;;;;;;;;;;;;;x
 PROV978;Kharkiv;;;;;;;;;;;;;x
@@ -3356,7 +3357,7 @@ PROV3355;Jan Mayen;;;;;;;;;;;;;x
 PROV3356;Daridere;;;;;;;;;;;;;x
 PROV3357;Val d’Aran;;;;;;;;;;;;;x
 PROV3358;Pluzine;;;;;;;;;;;;;x
-PROV3359;Salla;;;;;;;;;;;;;x
+PROV3359;Kirjasalo;;;;;;;;;;;;;x
 PROV3360;Lorri;;;;;;;;;;;;;x
 PROV3361;Cisr-i Mustafapasha;;;;;;;;;;;;;x
 PROV3362;Robione;;;;;;;;;;;;;x

--- a/TGC/localisation/00_map-regions.csv
+++ b/TGC/localisation/00_map-regions.csv
@@ -183,7 +183,7 @@ PRU_695;Ostpreußen;;;;;;;;;;;;;x
 PRU_701;Posen;;;;;;;;;;;;;x
 AUS_702;Westgalizien;;;;;;;;;;;;;x
 RUS_706;Varšava;;;;;;;;;;;;;x
-RUS_707;Suwalki;;;;;;;;;;;;;x
+RUS_707;Brêst;;;;;;;;;;;;;x
 RUS_708;Belastok;;;;;;;;;;;;;x
 RUS_715;Ljublin;;;;;;;;;;;;;x
 RUS_718;Minsk;;;;;;;;;;;;;x
@@ -213,12 +213,12 @@ TUR_803;Niš;;;;;;;;;;;;;x
 TUR_805;Southern Selânik;;;;;;;;;;;;;x
 TUR_806;Northern Selânik;;;;;;;;;;;;;x
 TUR_809;Northern Trakya;;;;;;;;;;;;;x
-TUR_810;Tuna;;;;;;;;;;;;;x
+TUR_810;Eyalet-i Rum-eli;;;;;;;;;;;;;x
 TUR_823;Central Selânik;;;;;;;;;;;;;x
 TUR_824;Yanya;;;;;;;;;;;;;x
 GRE_826;Peloponnisos;;;;;;;;;;;;;x
 TUR_830;Western Trakya;;;;;;;;;;;;;x
-TUR_832;Tirhala;;;;;;;;;;;;;x
+TUR_832;Tirhala Sanjak;;;;;;;;;;;;;x
 GRE_837;Stereá Elláda;;;;;;;;;;;;;x
 EGY_843;Aegean Islands;;;;;;;;;;;;;x
 TUR_853;Iskodra;;;;;;;;;;;;;x


### PR DESCRIPTION
Massive consolidation of renaming decisions of the Balkans, Russia and Europe.
Adding German renaming decisions for some parts of Russia and Ukraine.
Adding Turkish renaming decisions for territories which used to be part of the Ottoman Empire.
Adding Tatar renaming decisions for Crimea and Zaporozhia.
Adding Finnish renaming decision for Ingria.
Adding Turkish, Romanian and Bulgarian renaming decisions for Dobrudja.
Straightened up some of the mess of province renaming decisions in the Balkans.
Fixed some inconsistencies with province names and renaming.
Fixed and enabled renaming decisions which were commented out due to being broken.
A lot of formatting.