### PR TITLE
Adding Couto Misto, Morsenet and Athos to disable microstates decision

### DIFF
--- a/TGC/decisions/Setup.txt
+++ b/TGC/decisions/Setup.txt
@@ -8,16 +8,16 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_country_flag = test_dec }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = looking_through_options
 			set_country_flag = country_looking_through_options
 		}
 	}
-	
+
 	disable_options = {
 		alert = no
 		potential = {
@@ -25,10 +25,10 @@ political_decisions = {
 			has_country_flag = country_looking_through_options
 			NOT = { year = 1837 }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			clr_global_flag = looking_through_options
 			clr_country_flag = country_looking_through_options
@@ -48,7 +48,7 @@ political_decisions = {
 			set_global_flag = colonial_railroading_disabled
 		}
 	}
-	
+
 	option_disable_anarcho_liberals = {
 		alert = no
 		potential = {
@@ -57,15 +57,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = anarcho_liberals_disabled }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = anarcho_liberals_disabled
 		}
 	}
-	
+
 	option_disable_hpm_crisis = {
 		alert = no
 		potential = {
@@ -74,15 +74,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = revolution_n_counter_researched }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = revolution_n_counter_researched
 		}
 	}
-	
+
 	option_enable_fantasy_countries = {
 		alert = no
 		potential = {
@@ -91,15 +91,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = fantasy_countries_enabled }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = fantasy_countries_enabled
 		}
 	}
-	
+
 	option_enable_easter_eggs = {
 		alert = no
 		potential = {
@@ -108,15 +108,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = easter_eggs_enabled }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = easter_eggs_enabled
 		}
 	}
-	
+
 	option_disable_workplace_events = {
 		alert = no
 		potential = {
@@ -125,15 +125,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = workplace_events_disabled }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = workplace_events_disabled
 		}
 	}
-	
+
 	option_disable_bankruptcy_events = {
 		alert = no
 		potential = {
@@ -142,16 +142,16 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_country_flag = bankruptcy_events_disabled }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_country_flag = bankruptcy_events_disabled
 			any_country = { limit = { ai = no } set_country_flag = bankruptcy_events_disabled }
 		}
 	}
-	
+
 	option_spawn_occitania = {
 		alert = no
 		potential = {
@@ -160,10 +160,10 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = spawn_occitania }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = spawn_occitania
 			FRA = { add_accepted_culture = occitan }
@@ -196,7 +196,7 @@ political_decisions = {
 			OCC = { country_event = { id = 6016807 days = 2 } }
 		}
 	}
-	
+
 	#option_spawn_eic = {
 		#alert = no
 		#potential = {
@@ -205,10 +205,10 @@ political_decisions = {
 			#NOT = { year = 1837 }
 			#NOT = { has_global_flag = eic_spawned }
 		#}
-		
+
 		#allow = {
 		#}
-		
+
 		#effect = {
 			#set_global_flag = eic_spawned
 			#ENG = { country_event = 9990016 }
@@ -225,16 +225,16 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_global_flag = party_loyalty_eliminated }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = party_loyalty_eliminated
 			country_event = 6016814
 		}
 	}
-	
+
 ###Setup Decisions
 
 	1836_initial_setup = {
@@ -246,12 +246,12 @@ political_decisions = {
 			NOT = { year = 1838 }
 			NOT = { has_global_flag = 1836_set_up }
 		}
-		
+
 		allow = {
 			war = no
 			is_vassal = no
 		}
-		
+
 		effect = {
 			set_global_flag = 1836_set_up
 			set_country_flag = existing_country
@@ -305,7 +305,7 @@ political_decisions = {
 					literacy = 0.05
 				}
 			}
-			
+
 			any_country = {
 				limit = {
 					exists = yes
@@ -355,7 +355,7 @@ political_decisions = {
 					literacy = 0.02
 				}
 			}
-			
+
 			any_country = {
 				limit = {
 					exists = yes
@@ -396,7 +396,7 @@ political_decisions = {
 					literacy = 0.02
 				}
 			}
-			
+
 			any_country = {
 				limit = {
 					exists = yes
@@ -417,7 +417,7 @@ political_decisions = {
 					literacy = 0.05
 				}
 			}
-			
+
 				any_pop = {
 					limit = {
 						strata = rich
@@ -450,9 +450,9 @@ political_decisions = {
 					}
 					literacy = 0.02
 				}
-			
+
 			#################Class Literacy Setup######################
-			
+
 			#################Provinces Setup######################
 			2509 = { add_province_modifier = { name = small_immigration_boom duration = 10950 } }	#Auckland, NZ
 			46 = { add_province_modifier = { name = small_immigration_boom duration = 10950 } }		#Toronto, CA
@@ -474,13 +474,13 @@ political_decisions = {
 			2172 = { set_province_flag = mexico_city }
 			1616 = { set_province_flag = summer_palace }
 			#################Provinces Setup######################
-			
+
 			#################Giving Starting Money to Pops and Countries######################
 			any_country = { limit = { is_greater_power = yes } capitalists = { money = 1000 } aristocrats = { money = 500 } artisans = { money = 200 } }
 			any_country = { limit = { is_secondary_power = yes } capitalists = { money = 800 } aristocrats = { money = 400 } artisans = { money = 100 } }
 			any_country = {
 				limit = { is_greater_power = no is_secondary_power = no civilized = yes }
-				capitalists = { money = 500 } aristocrats = { money = 200 } artisans = { money = 50 } 
+				capitalists = { money = 500 } aristocrats = { money = 200 } artisans = { money = 50 }
 			}
 			any_country = { limit = { is_greater_power = yes NOT = { tag = SPA tag = TUR } } treasury = 10000 }
 			any_country = { limit = { OR = { is_secondary_power = yes tag = SPA tag = TUR } } treasury = 5000 }
@@ -497,9 +497,9 @@ political_decisions = {
 					}
 					reduce_pop = 0.75
 				}
-			}	
+			}
 			#################Giving Starting Money to Pops and Countries######################
-			
+
 			#################Japan Setup######################
 			#Shogun Faction
 			any_country = {
@@ -579,10 +579,10 @@ political_decisions = {
 				random_owned = {
 					limit = { owner = { foreign_training = yes_foreign_training } }
 					owner = { add_country_modifier = { name = isolationist_foreign_training duration = -1 } }
-				}				
+				}
 			}
 			#################Japan Setup######################
-			
+
 			#################Ethiopia Setup######################
 			any_country = {
 				limit = {
@@ -600,21 +600,21 @@ political_decisions = {
 				add_country_modifier = { name = exploiting_the_land duration = 10950 }
 			}
 			#################Ethiopia Setup######################
-			
+
 			#################Setup UK Ideology######################
 			ENG = {
 				any_owned = { limit = { is_core = ENG }
-					any_pop = { 
+					any_pop = {
 						limit = { is_culture_group = british }
-						ideology = { factor = 0.2 value = liberal } 
-					} 
+						ideology = { factor = 0.2 value = liberal }
+					}
 				}
 				ENG_258 = { any_pop = { ideology = { factor = 0.6 value = liberal } } }
 				ENG_260 = { any_pop = { ideology = { factor = 0.6 value = liberal } } }
 				ENG_263 = { any_pop = { ideology = { factor = 0.6 value = liberal } } }
 			}
 			#################Setup UK Ideology######################
-			
+
 			URU = { add_country_modifier = { name = credit_risk duration = 3650 } }
 			ECU = { add_country_modifier = { name = credit_risk duration = 3650 } }
 			UCA = { add_country_modifier = { name = credit_risk duration = 1825 } }
@@ -622,7 +622,7 @@ political_decisions = {
 			SPU = { add_country_modifier = { name = credit_risk duration = 5475 } }
 			PRG = { add_country_modifier = { name = unrecognized_country duration = 3650 } }
 			RGS = { add_country_modifier = { name = unrecognized_country duration = 3650 } }
-			
+
 			#################Setup Texas######################
 			TEX = {
 				small_arms = 100
@@ -642,22 +642,22 @@ political_decisions = {
 				}
 			}
 			#################Setup Texas######################
-			
+
 			#################Setup SWI######################
 			SWI = { 603 = { aristocrats  = { money = 12000 } } }
 			SWI = { any_pop = { limit = { has_pop_religion = protestant } ideology = { factor = 0.5 value = liberal } } }
 			SWI = { any_pop = { limit = { has_pop_religion = catholic } ideology = { factor = 0.5 value = conservative } } }
 			#################Setup SWI######################
-			
+
 			#################Belgian War of Independence######################
 			NET = { war_exhaustion = 40 }
 			BEL = { war_exhaustion = 20 }
 			#################Belgian War of Independence######################
-			
+
 			#################1832 War with Colombia######################
 			ECU = { war_exhaustion = 50 any_pop = { militancy = 3 } }
 			#################1832 War with Colombia######################
-			
+
 			#################Isolationist Uncivs Setup######################
 			any_country = {
 				limit = {
@@ -666,10 +666,10 @@ political_decisions = {
 					NOT = { primary_culture = japanese }
 					NOT = { tag = QNG }
 					OR = {
-						capital_scope = { continent = africa } 
-						capital_scope = { continent = west_africa } 
-						capital_scope = { continent = central_africa } 
-						capital_scope = { continent = east_africa } 
+						capital_scope = { continent = africa }
+						capital_scope = { continent = west_africa }
+						capital_scope = { continent = central_africa }
+						capital_scope = { continent = east_africa }
 						capital_scope = { continent = south_west_africa }
 						capital_scope = { continent = oceania }
 						capital_scope = { continent = asia }
@@ -677,14 +677,14 @@ political_decisions = {
 				}
 				relation = { who = USA value = -75 }
 			}
-			
+
 			random_country = {
 				limit = {
 					tag = SIA
 				}
 				add_country_modifier = { name = uncivilized_isolationism duration = -1 }
 			}
-			
+
 			any_country = {
 				limit = {
 					OR = {
@@ -700,7 +700,7 @@ political_decisions = {
 				}
 				add_country_modifier = { name = isolationist_foreign_naval_schools duration = -1 }
 			}
-			
+
 			any_country = {
 				limit = {
 					OR = {
@@ -716,7 +716,7 @@ political_decisions = {
 				}
 				add_country_modifier = { name = isolationist_foreign_officers duration = -1 }
 			}
-			
+
 			any_country = {
 				limit = {
 					OR = {
@@ -732,7 +732,7 @@ political_decisions = {
 				}
 				add_country_modifier = { name = isolationist_foreign_naval_officers duration = -1 }
 			}
-			
+
 			any_country = {
 				limit = {
 					OR = {
@@ -748,31 +748,31 @@ political_decisions = {
 				}
 				add_country_modifier = { name = isolationist_foreign_training duration = -1 }
 			}
-			
+
 			any_country = {
 				limit = { has_country_flag = lacking_writing_system exists = yes }
-				add_country_modifier = { name = lacks_writing_system duration = -1 } 
+				add_country_modifier = { name = lacks_writing_system duration = -1 }
 			}
-			
+
 			#################Isolationist Uncivs Setup######################
-			
+
 			#################Uncivs  Pops Setup######################
 			ZUL = { add_country_modifier = { name = assegai duration = -1 } }
-			
+
 			NEJ = {
 				add_country_modifier = { name = wahhabism_in_nejd duration = -1 }
-			
+
 				any_pop = { limit = { is_state_religion = yes }
 					dominant_issue = { factor = 0.60 value = moralism }
 					dominant_issue = { factor = 0.30 value = jingoism }
 					ideology = { factor = 0.75 value = conservative }
 				}
 			}
-			
+
 			any_pop = { limit = { has_pop_religion = animist } literacy = -0.5 }
 			any_country = { limit = { exists = yes } any_pop = { limit = { has_pop_religion = animist } literacy = -0.5 } }
 			#################Uncivs  Pops Setup######################
-			
+
 			#################Slaves and Serfs  Pops Setup######################
 			serfs = { militancy = -9 consciousness = -9 literacy = -0.99 }
 			slaves = { literacy = -0.99 }
@@ -787,7 +787,7 @@ political_decisions = {
 			any_pop = { limit = { has_pop_culture = gypsy } literacy = -0.99 }
 			any_country = { limit = { exists = yes } any_pop = { limit = { has_pop_culture = gypsy } literacy = -0.99 } }
 			#################Slaves and Serfs  Pops Setup######################
-			
+
 			#################Romanian Pops Setup######################
 			any_country = {
 				limit = { OR = { tag = MOL tag = WAL } }
@@ -798,10 +798,10 @@ political_decisions = {
 			}
 			WAL_665 = { add_province_modifier = { name = small_baby_boom duration = 2555 } }
 			MOL_673 = { add_province_modifier = { name = small_baby_boom duration = 2555 } }
-			
+
 			SER_794 = { add_province_modifier = { name = baby_boom duration = 3650 } }
 			#################Romanian Pops Setup######################
-			
+
 			#################Government Flags Setup######################
 			any_country = { limit = { government = absolute_monarchy NOT = { has_country_flag = absolute_monarchy_gov } exists = yes }
 				clr_country_flag = communist_gov
@@ -813,7 +813,7 @@ political_decisions = {
 				clr_country_flag = fascist_gov
 				clr_country_flag = anarcho_liberal_gov
 			}
-			
+
 			any_country = { limit = { government = hms_government NOT = { has_country_flag = constitutional_monarchy_gov } exists = yes }
 				clr_country_flag = communist_gov
 				clr_country_flag = absolute_monarchy_gov
@@ -824,7 +824,7 @@ political_decisions = {
 				clr_country_flag = fascist_gov
 				clr_country_flag = anarcho_liberal_gov
 			}
-			
+
 			any_country = { limit = { government = democracy NOT = { has_country_flag = democracy_gov } exists = yes }
 				clr_country_flag = communist_gov
 				clr_country_flag = absolute_monarchy_gov
@@ -835,7 +835,7 @@ political_decisions = {
 				clr_country_flag = fascist_gov
 				clr_country_flag = anarcho_liberal_gov
 			}
-			
+
 			any_country = { limit = { government = presidential_dictatorship NOT = { has_country_flag = presidential_dictatorship_gov } exists = yes }
 				clr_country_flag = communist_gov
 				clr_country_flag = absolute_monarchy_gov
@@ -846,7 +846,7 @@ political_decisions = {
 				clr_country_flag = fascist_gov
 				clr_country_flag = anarcho_liberal_gov
 			}
-			
+
 			any_country = { limit = { government = prussian_constitutionalism NOT = { has_country_flag = semi_constitutional_monarchy_gov } exists = yes }
 				clr_country_flag = communist_gov
 				clr_country_flag = absolute_monarchy_gov
@@ -857,42 +857,42 @@ political_decisions = {
 				clr_country_flag = fascist_gov
 				clr_country_flag = anarcho_liberal_gov
 			}
-			
+
 			any_country = { limit = { civilized = no foreign_weapons = yes_foreign_weapons NOT = { has_country_flag = using_foreign_weapons } }
 				set_country_flag = using_foreign_weapons
 			}
-			
+
 			any_country = { limit = { civilized = no foreign_artillery = yes_foreign_artillery NOT = { has_country_flag = using_foreign_artillery } }
 				set_country_flag = using_foreign_artillery
 			}
-			
+
 			any_country = { limit = { civilized = no foreign_navies = yes_foreign_navies NOT = { has_country_flag = using_foreign_ships } }
 				set_country_flag = using_foreign_ships
 			}
-			
+
 			any_country = { limit = { civilized = no western_shipyards = yes_western_shipyards NOT = { has_country_flag = using_foreign_shipyards } }
 				set_country_flag = using_foreign_shipyards
 			}
-			
+
 			#################Government Flags Setup######################
-						
+
 			QNG = { add_country_modifier = { name = corrupt_army duration = 10950 } }
 			ENT = { add_country_modifier = { name = caudillo_leaders duration = 7300 } }
 			CRT = { add_country_modifier = { name = caudillo_leaders duration = 1825 } }
 			HAI = { add_country_modifier = { name = divided_society duration = 10950 } }
-				
+
 			any_greater_power = {
 				limit = { NOT = { tag = PRU } }
 				diplomatic_influence = { who = NCT value = -400 }
 			}
 
 			MEX = { add_country_modifier = { name = fight_the_power duration = 3650 } }
-			
-			1493 = { 
+
+			1493 = {
 				add_province_modifier = {
 					name = canton_system
 					duration = -1
-				}	
+				}
 				add_province_modifier = {
 					name = "foreign_smugglers"
 					duration = -1
@@ -905,7 +905,7 @@ political_decisions = {
 			QNG = {
 				any_owned = {
 					limit = {
-						OR = { 
+						OR = {
 							state_id = 1493
 							state_id = 1482
 						}
@@ -918,7 +918,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	option_spectator = {
 		alert = no
 		potential = {
@@ -927,15 +927,15 @@ political_decisions = {
 			NOT = { year = 1837 }
 			NOT = { has_country_flag = spectator }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_country_flag = spectator
 		}
 	}
-#from FlavourMod_Setup_CleanUp	
+#from FlavourMod_Setup_CleanUp
 	enable_debug_decision = {
 		potential = {
 			ai = no
@@ -943,9 +943,9 @@ political_decisions = {
 			NOT = { has_country_flag = enable_debug_decision }
 			NOT = { year = 1837 }
 		}
-		
+
 		allow = { }
-		
+
 		effect = { set_country_flag = enable_debug_decision }
 	}
 
@@ -955,16 +955,16 @@ political_decisions = {
 			has_country_flag = enable_debug_decision
 			NOT = { has_country_flag = test_dec }
 		}
-		
+
 		allow = { }
-		
+
 		effect = {
 			#QNG = { change_tag = QNG }
 			FRA = { change_tag = FRA }
 			set_country_flag = test_dec
 		}
 	}
-	
+
 	disable_microstates = {
 		potential = {
 			ai = no
@@ -983,6 +983,12 @@ political_decisions = {
 			AUS = { inherit = LIE }
 			3266 = { remove_core = SMR add_core = PAP add_core = ITA }
 			PAP = { inherit = SMR }
+			3325 = { remove_core = CUO add_core = SPA }
+			SPA = { inherit = CUO }
+			3320 = { remove_core = MRN add_core = BEL }
+			BEL = { inherit = MRN }
+			3350 = { remove_core = ATH add_core = TUR }
+			TUR = { inherit = ATH }
 		}
 	}
 }


### PR DESCRIPTION
Extends the Disable Microstates decision to include the new microstates of Couto Misto, Morsenet and Athos.