### PR TITLE
Brushing up on Treaty Ports

### DIFF
--- a/TGC/decisions/ENG.txt
+++ b/TGC/decisions/ENG.txt
@@ -121,7 +121,7 @@ political_decisions = {
 			set_country_flag = elementary_my_dear_watson
 		}
 	}
-	
+
 	ionian_islands_question = {
 		picture = ionian_islands_question
 		potential = {
@@ -136,12 +136,12 @@ political_decisions = {
 			}
 			GRE = { exists = yes }
 		}
-		
+
 		allow = {
 			state_n_government = 1
 			war = no
 		}
-		
+
 		effect = {
 			random_country = {
 				limit = {
@@ -162,7 +162,7 @@ political_decisions = {
 			prestige = 10
 			badboy = -4
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -191,10 +191,10 @@ political_decisions = {
 			any_owned_province = { is_core = RHO }
 			RHO = { exists = no }
 			NOT = {
-				capital_scope = { continent = africa } 
-				capital_scope = { continent = west_africa } 
-				capital_scope = { continent = central_africa } 
-				capital_scope = { continent = east_africa } 
+				capital_scope = { continent = africa }
+				capital_scope = { continent = west_africa }
+				capital_scope = { continent = central_africa }
+				capital_scope = { continent = east_africa }
 				capital_scope = { continent = south_west_africa }
 			}
 			NOT = { has_country_flag = post_colonial_country }
@@ -202,7 +202,7 @@ political_decisions = {
 			civilized = yes
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		allow = {
 			war = no
 			SAF = { exists = yes }
@@ -218,7 +218,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			prestige = 3
 			RHO = { set_country_flag = post_colonial_country }
@@ -227,9 +227,9 @@ political_decisions = {
 			any_owned = { limit = { is_core = RHO } secede_province = RHO }
 			create_vassal = RHO
 			create_alliance = RHO
-			diplomatic_influence = { who = RHO value = 400 }	
+			diplomatic_influence = { who = RHO value = 400 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -238,7 +238,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	rhodesia_charter = {
 		potential = {
 			tag = ENG
@@ -251,9 +251,9 @@ political_decisions = {
 			owns = 2635
 			NOT = { has_country_flag = ian_would_be_proud }
 		}
-		
+
 		allow = { invention = mission_to_civilize }
-		
+
 		effect = {
 			prestige = 10
 			ENG_2068 = { add_core = RHO }
@@ -304,7 +304,7 @@ political_decisions = {
 			set_country_flag = ian_would_be_proud
 		}
 	}
-	
+
 	treaty_of_heligoland = {
 		picture = the_heligoland_question
 		potential = {
@@ -395,7 +395,7 @@ political_decisions = {
 
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	treaty_of_nanking = {
 	picture = treaty_of_nanking
 		potential = {
@@ -480,7 +480,7 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	trucial_protectorate = {
 		picture = map_arabia
 		potential = {
@@ -492,7 +492,7 @@ political_decisions = {
 			revolution_n_counterrevolution = 1
 			NOT = { has_global_flag = created_trucial_protectorate }
 		}
-		
+
 		allow = {
 			war = no
 			ABU = {
@@ -502,14 +502,14 @@ political_decisions = {
 			}
 			mass_politics = 1
 		}
-		
+
 		effect = {
 			set_global_flag = created_trucial_protectorate
 			prestige = 5
 			create_vassal = ABU
 		}
 	}
-	
+
 	aden_protectorate = {
 		picture = aden_protectorate
 		potential = {
@@ -526,7 +526,7 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = created_aden_protectorate }
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -567,7 +567,7 @@ political_decisions = {
 			}
 			YEM = { exists = no }
 		}
-		
+
 		effect = {
 			set_global_flag = created_aden_protectorate
 			badboy = -3
@@ -608,8 +608,8 @@ political_decisions = {
 			}
 			random_owned = {
 				limit = { owner = { primary_culture = british } }
-				YEM = { 
-					government = colonial_company 
+				YEM = {
+					government = colonial_company
 					military_reform = yes_foreign_weapons
 					military_reform = yes_foreign_officers
 					military_reform = yes_foreign_naval_officers
@@ -623,10 +623,10 @@ political_decisions = {
 			random_owned = { limit = { exists = ABU } owner = { diplomatic_influence = { who = ABU value = 25 } } }
 			random_owned = { limit = { exists = KWT } owner = { diplomatic_influence = { who = KWT value = 25 } } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	gold_coast_treaty = {
 		picture = treaty_signing
 		potential = {
@@ -645,7 +645,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = gold_coast_treaty }
 		}
-		
+
 		allow = {
 			war = no
 			money = 10000
@@ -654,13 +654,13 @@ political_decisions = {
 				owns = 1909
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = gold_coast_treaty
 			treasury = -10000
 			NET = { country_event = 36960 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -673,7 +673,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	annex_fiji = {
 		picture = dreams_of_empire
 		potential = {
@@ -688,13 +688,13 @@ political_decisions = {
 				government = absolute_monarchy
 			}
 		}
-		
+
 		allow = {
 			war = no
 			money = 10000
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		effect = {
 			prestige = 3
 			treasury = -10000
@@ -705,7 +705,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	invest_in_irish = {
 		picture = ireland
 		potential = {
@@ -726,14 +726,14 @@ political_decisions = {
 			}
 			any_owned_province = { is_core = IRE }
 		}
-		
+
 		allow = {
 			prestige = 50
 			money = 850001
 			NOT = { citizenship_policy = residency }
 			social_science = 1
 		}
-		
+
 		effect = {
 			set_country_flag = invest_in_irish
 			random_owned = {
@@ -755,12 +755,12 @@ political_decisions = {
 				militancy = -5
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	#irish_integration = {
 	#	picture = embrace_minority
 	#	potential = {
@@ -771,13 +771,13 @@ political_decisions = {
 	#			NOT = { has_province_modifier = irish_integration }
 	#		}
 	#	}
-	#	
+	#
 	#	allow = {
 	#		money = 50000
 	#		social_science = 1
 	#		psychoanalysis = 1
 	#	}
-	#	
+	#
 	#	effect = {
 	#		prestige = 20
 	#		treasury = -50000
@@ -790,7 +790,7 @@ political_decisions = {
 	#		}
 	#	}
 	#}
-	
+
 	the_great_game_makran = {
 		picture = gtfo
 		potential = {
@@ -810,21 +810,21 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		allow = {
 			MAK = { average_militancy = 4 }
 		}
-		
+
 		effect = {
 			MAK = { annex_to = THIS }
 			badboy = 2
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	the_great_game_kalat = {
 		picture = gtfo
 		potential = {
@@ -844,21 +844,21 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		allow = {
 			KAL = { average_militancy = 4 }
 		}
-		
+
 		effect = {
 			KAL = { annex_to = THIS }
 			badboy = 2
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	the_great_game_panjab = {
 		picture = gtfo
 		potential = {
@@ -877,16 +877,16 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		allow = {
 			PNJ = { average_militancy = 4 }
 		}
-		
+
 		effect = {
 			PNJ = { annex_to = THIS }
 		}
 	}
-	
+
 	the_great_game_sindh = {
 		picture = gtfo
 		potential = {
@@ -905,22 +905,22 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		allow = {
 			SIN = { average_militancy = 3 }
 		}
-		
+
 		effect = {
 			SIN = { annex_to = THIS }
 			badboy = 2
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
-	
+
+
 	build_the_big_ben = {
 		picture = bigben
 		potential = {
@@ -929,11 +929,11 @@ political_decisions = {
 			tag = ENL
 			}
 			year = 1844
-			NOT = { has_country_flag = big_ben_construction }		
+			NOT = { has_country_flag = big_ben_construction }
 			NOT = { year = 1860 }
 			300 = { NOT = { has_province_modifier = the_big_ben } }
 		}
-		
+
 		allow = {
 			NOT = { year = 1860 }
 			money = 7500
@@ -944,7 +944,7 @@ political_decisions = {
 					value = 0.3
 				}
 		}
-		
+
 		effect = {
 			set_country_flag = big_ben_construction
 			country_event = 3697000
@@ -963,20 +963,20 @@ political_decisions = {
 			owns = 2635
 			NOT = { has_country_flag = renaming_act }
 		}
-		
+
 		allow = {
 			owns = 2068
 			owns = 2070
 			owns = 2635
 		}
-		
+
 		effect = {
 			set_country_flag = renaming_act
 			2068 = { state_scope = { change_region_name = "Southern Rhodesia" } }
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	durand_line = {
 		picture = mortimer_durand
 		potential = {
@@ -988,12 +988,12 @@ political_decisions = {
 			NOT = { has_country_flag = durand_line }
 			NOT = { year = 1920 }
 		}
-		
+
 		allow = {
 			war = no
-			OR = { 
+			OR = {
 				invention = the_dark_continent
-				AND = { 
+				AND = {
 					AFG = { vassal_of = THIS }
 					revolution_n_counterrevolution = 1
 				}
@@ -1001,14 +1001,14 @@ political_decisions = {
 			NOT = { year = 1920 }
 			#NOT = { relation = { who = AFG value = 100 } }
 		}
-		
+
 		effect = {
 			set_country_flag = durand_line
 			AFG = { country_event = 3697010 }
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	unite_north_yemen_existing = {
 		picture = aden_protectorate
 		potential = {
@@ -1016,7 +1016,7 @@ political_decisions = {
 				NOT = { 1178 = { is_core = YEM } }
 				NOT = { 1179 = { is_core = YEM } }
 				NOT = { 1180 = { is_core = YEM } }
-			}			
+			}
 			NOT = { tag = NYE }
 			NYE = { exists = yes }
 			OR = {
@@ -1030,7 +1030,7 @@ political_decisions = {
 					}
 				}
 			}
-		
+
 		allow = {
 			nationalism_n_imperialism = 1
 			war = no
@@ -1039,9 +1039,9 @@ political_decisions = {
 				OR = {
 					vassal_of = THIS
 					in_sphere = THIS
-				all_core = { 
+				all_core = {
 					OR = {
-						owned_by = THIS 
+						owned_by = THIS
 						owner = { in_sphere = THIS }
 						owner = { vassal_of = THIS }
 						}
@@ -1058,7 +1058,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			prestige = 5
 			NYE = { all_core = { add_core = YEM } }
@@ -1066,7 +1066,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	unite_yemeni_colonies = {
 		picture = aden_protectorate
 		potential = {
@@ -1084,23 +1084,23 @@ political_decisions = {
 			}
 			YEM = { exists = no }
 		}
-		
+
 		allow = {
 			nationalism_n_imperialism = 1
 			war = no
 			YEM = { war = no all_core = { owned_by = THIS } }
 			NYE = {
 				war = no
-				all_core = { 
+				all_core = {
 					OR = {
-						owned_by = THIS 
+						owned_by = THIS
 						owner = { in_sphere = THIS }
 						owner = { vassal_of = THIS }
 					}
 				}
 			}
 		}
-		
+
 		effect = {
 			prestige = 5
 			NYE = { tech_school = unciv_tech_school all_core = { add_core = YEM } }
@@ -1108,7 +1108,7 @@ political_decisions = {
 			1179 = { secede_province = THIS }
 			1180 = { secede_province = THIS }
 			YEM = { tech_school = unciv_tech_school capital = 1178 }
-			
+
 			random_owned = { limit = { exists = NEJ } owner = { diplomatic_influence = { who = NEJ value = 50 } } }
 			random_owned = { limit = { exists = HAL } owner = { diplomatic_influence = { who = HAL value = 50 } } }
 			random_owned = { limit = { exists = BHR } owner = { diplomatic_influence = { who = BHR value = 50 } } }
@@ -1116,14 +1116,14 @@ political_decisions = {
 			random_owned = { limit = { exists = ABU } owner = { diplomatic_influence = { who = ABU value = 50 } } }
 			random_owned = { limit = { exists = KWT } owner = { diplomatic_influence = { who = KWT value = 50 } } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
-	anglo_persian_oil_company = { 
+	anglo_persian_oil_company = {
 		picture = map_arabia
-		
-		potential = { 
+
+		potential = {
 			tag = ENG
 			year = 1900
 			NOT = {	has_country_flag = apoc	}
@@ -1131,31 +1131,31 @@ political_decisions = {
 			invention = oil_pumping_machinery
 			PER = { exists = yes }
 		}
-		
+
 		allow = {
 			money = 150001
 			PER = {
 				OR = {
 					part_of_sphere = no
-					in_sphere = THIS 
+					in_sphere = THIS
 				}
 			}
 		}
-		
-		effect = { 
+
+		effect = {
 			set_country_flag = apoc
 			treasury = -150000
 			prestige = 25
 			PER = { country_event = 110011 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	
-	johor_protectorate = { 
+
+
+	johor_protectorate = {
 		picture = map_east_indies
-		
+
 		potential = {
 			NOT = { has_country_flag = integrated_johore }
 			OR = {
@@ -1171,7 +1171,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			OR = {
 			AND = {
@@ -1194,8 +1194,8 @@ political_decisions = {
 				}
 			}
 		}
-		
-		effect = { 
+
+		effect = {
 			set_country_flag = integrated_johore
 			JOH = { civilized = no tech_school = unciv_tech_school }
 			create_vassal = JOH
@@ -1203,7 +1203,7 @@ political_decisions = {
 			1388 = { remove_core = JOH add_core = PRK }
 			1389 = { remove_core = JOH add_core = PRK }
 			1391 = { remove_core = JOH add_core = PHG }
-			
+
 			random_owned = { limit = { exists = PRK } owner = { diplomatic_influence = { who = PRK value = 15 } } }
 			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
 			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
@@ -1213,10 +1213,10 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
-	pahang_protectorate = { 
+
+	pahang_protectorate = {
 		picture = map_east_indies
-		
+
 		potential = {
 			is_sphere_leader_of = PHG
 			NOT = { has_country_flag = integrated_pahang }
@@ -1229,7 +1229,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			OR = {
 				revolution_n_counterrevolution = 1
@@ -1239,15 +1239,15 @@ political_decisions = {
 				}
 			}
 		}
-		
-		effect = { 
+
+		effect = {
 			set_country_flag = integrated_pahang
 			PHG = { civilized = no tech_school = unciv_tech_school }
 			PHG = { all_core = { add_province_modifier = { name = nationalist_agitation duration = 730 } } }
 			PHG = { all_core = { remove_core = JOH } }
 			create_vassal = PHG
 			badboy = 1
-			
+
 			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
 			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
 			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
@@ -1257,10 +1257,10 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
-	selangor_protectorate = { 
+
+	selangor_protectorate = {
 		picture = map_east_indies
-		
+
 		potential = {
 			is_sphere_leader_of = SLG
 			NOT = { has_country_flag = integrated_selangor }
@@ -1273,7 +1273,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			OR = {
 				revolution_n_counterrevolution = 1
@@ -1283,14 +1283,14 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = integrated_selangor
 			SLG = { civilized = no tech_school = unciv_tech_school }
 			create_vassal = SLG
 			SLG = { all_core = { remove_core = JOH } }
 			badboy = 1
-			
+
 			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
 			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
 			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
@@ -1300,10 +1300,10 @@ political_decisions = {
 			}
 			ai_will_do = { factor = 1 }
 		}
-	
-	perak_protectorate = { 
+
+	perak_protectorate = {
 		picture = map_east_indies
-		
+
 		potential = {
 			is_sphere_leader_of = PRK
 			NOT = { has_country_flag = integrated_perak }
@@ -1316,7 +1316,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			OR = {
 				revolution_n_counterrevolution = 1
@@ -1326,14 +1326,14 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = integrated_perak
 			PRK = { civilized = no tech_school = unciv_tech_school }
 			create_vassal = PRK
 			PRK = { all_core = { remove_core = JOH } }
 			badboy = 1
-			
+
 			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
 			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
 			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
@@ -1343,7 +1343,7 @@ political_decisions = {
 		}
 			ai_will_do = { factor = 1 }
 		}
-	
+
 	canadian_lands = {
 		picture = canadian_dominion
 		alert = no
@@ -1376,11 +1376,11 @@ political_decisions = {
 				has_country_flag = CAN_independence_refused
 			}
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			any_owned = {
 				limit = {
@@ -1408,18 +1408,18 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	tasmania_penal_colony = {
 		picture = drain_the_pinsk_marshes
-		
+
 		potential = {
 			owns = 2482
 			OR = {
-				2482 = { has_province_modifier = penal_colony }	
+				2482 = { has_province_modifier = penal_colony }
 				NOT = { has_global_flag = tasmania_renamed }
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
@@ -1428,7 +1428,7 @@ political_decisions = {
 				year = 1853
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = tasmania_renamed
 			2482 = {
@@ -1439,11 +1439,11 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	cede_aden = {
 		picture = aden_protectorate
 		alert = no
-		
+
 		potential = {
 			has_global_flag = created_aden_protectorate
 			OR = {
@@ -1458,8 +1458,8 @@ political_decisions = {
 				great_wars_enabled = yes
 			}
 		}
-		
-		
+
+
 		allow = {
 			war = no
 			OR = {
@@ -1468,8 +1468,8 @@ political_decisions = {
 					owner = {
 						OR = {
 							vassal_of = THIS
-							AND = { in_sphere = THIS is_vassal = no } 
-						} 
+							AND = { in_sphere = THIS is_vassal = no }
+						}
 					}
 				}
 			}
@@ -1479,36 +1479,36 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		effect = {
 			badboy = -2
 			1412 = { remove_core = THIS }
-			
+
 			random_country = { limit = { owns = 1412 num_of_cities = 2 }
 				1412 = { secede_province = THIS }
 			}
-			
+
 			random_owned = { limit = { province_id = 1412 }
 				1412 = { secede_province = YEM add_core = YEM remove_core = THIS remove_core = LHJ }
 			}
-			
+
 			random_country = { limit = { owns = 1412 NOT = { num_of_cities = 2 } }
 				1412 = { add_core = YEM remove_core = THIS remove_core = LHJ }
 				annex_to = YEM
 			}
-			
+
 			random_owned = { limit = { owner = { is_greater_power = yes } } owner = { diplomatic_influence = { who = YEM value = 100 } } }
 			relation = { who = YEM value = 100 }
-			random_country = { limit = { tag = YEM NOT = { capital = 1178 } } capital = 1412 } 
+			random_country = { limit = { tag = YEM NOT = { capital = 1178 } } capital = 1412 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
 				1412 = { any_neighbor_province = { owned_by = THIS } }
 			}
-			
+
 			modifier = {
 				factor = 0
 				owns = 1412
@@ -1518,7 +1518,7 @@ political_decisions = {
 
 	christimas_and_cocos_adminstration = {
 		picture = dreams_of_empire
-		
+
 		potential = {
 			owns = 2244
 			OR = {
@@ -1535,13 +1535,13 @@ political_decisions = {
 				AST = { vassal_of = THIS }
 				FAS = { vassal_of = THIS }
 			}
-			OR = { 
+			OR = {
 				AND = {
 					OR = { FRA = { has_country_flag = australia_organized } BOR = { has_country_flag = australia_organized } }
 					2244 = { NOT = { is_core = FAS } }
 				}
-				AND = { 
-					OR = { 
+				AND = {
+					OR = {
 						primary_culture = british
 						primary_culture = australian
 					}
@@ -1549,12 +1549,12 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
@@ -1569,7 +1569,7 @@ political_decisions = {
 				2244 = { add_core = AST }
 				random_country = { limit = { tag = AST exists = yes } 2244 = { secede_province = AST } }
 			}
-			
+
 			random_owned = {
 				limit = {
 					owner = {
@@ -1584,11 +1584,11 @@ political_decisions = {
 				random_country = { limit = { tag = FAS exists = yes } 2244 = { secede_province = FAS } }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	
+
+
 	the_foster_act = {
 		picture = william_foster
 		potential = {
@@ -1596,42 +1596,42 @@ political_decisions = {
 			NOT = { school_reforms = good_schools}
 			NOT = { has_country_flag = foster_act_enacted }
 			year = 1865
-		}		
-		
+		}
+
 		allow = {
 			war = no
-			OR = { 
+			OR = {
 				biologism = 1
 				revolution_n_counterrevolution = 1
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = foster_act_enacted
-			
+
 			random_owned = {
 				limit = { owner = { school_reforms = acceptable_schools } }
 				owner = { social_reform = good_schools }
 			}
-			
+
 			random_owned = {
 				limit = { owner = { school_reforms = low_schools } }
 				owner = { social_reform = acceptable_schools }
 			}
-			
+
 			random_owned = {
 				limit = { owner = { school_reforms = no_schools } }
 				owner = { social_reform = low_schools }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
-	
+
+
 	londonderry_renaming_act = {
 		picture = londonderry_quay
-		
+
 		potential = {
 			OR = {
 				AND = {
@@ -1645,28 +1645,28 @@ political_decisions = {
 			}
 			owns = 255
 		}
-		
-		
+
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
-			
+
 			random_owned = {
 				limit = { owner = { primary_culture = irish } }
 				owner = { set_global_flag = londonderry_renamed 255 = { change_province_name = "Derry" } }
 			}
-			
+
 			random_owned = {
 				limit = { owner = { primary_culture = british } }
 				owner = { clr_global_flag = londonderry_renamed 255 = { change_province_name = "Londonderry" } }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from ACW.txt
 	webster_ashburton_treaty = {
 		potential = {
@@ -1677,7 +1677,7 @@ political_decisions = {
 				NEN = { any_owned_province = { region = USA_247 } }
 			}
 		}
-		
+
 		allow = {
 			owns = 250
 			OR = {
@@ -1691,7 +1691,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			158 = { remove_core = CAN }
 			250 = { remove_core = CAN }
@@ -1703,7 +1703,7 @@ political_decisions = {
 			249 = { owner = { country_event = 44122 } }
 			set_global_flag = webster_ashburton_signed
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -1765,9 +1765,9 @@ political_decisions = {
 				add_core = COL
 				add_core = CAN
 				remove_core = RPL
-			}	
+			}
 			#Remove RPL & USA Cores, if owned
-			RPL = {			
+			RPL = {
 				any_owned = {
 					limit = {
 						OR = {
@@ -1805,17 +1805,17 @@ political_decisions = {
 			57 = { NOT = { life_rating = 36 } }
 			57 = { NOT = { has_province_modifier = genocide } }
 		}
-		
+
 		allow = {
 			war = no
 			early_railroad = 1
 			year = 1850
 		}
-		
+
 		effect = {
-			57 = { 
-				change_province_name = "Ottawa" 
-				life_rating = 5 
+			57 = {
+				change_province_name = "Ottawa"
+				life_rating = 5
 				add_province_modifier = {
 					name = recently_built_city
 					duration = 1450
@@ -1824,7 +1824,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	alaskan_frontier = {
 		picture = fort_selkirk
 		potential = {
@@ -1841,12 +1841,12 @@ political_decisions = {
 			}
 			6 = { empty = yes }
 		}
-		
+
 		allow = {
 			war = no
 			invention = mission_to_civilize
 		}
-		
+
 		effect = {
 			6 = {
 				secede_province = THIS
@@ -1862,7 +1862,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	rupert_land_act = {
 		picture = canadian_dominion
 		potential = {
@@ -1871,7 +1871,7 @@ political_decisions = {
 				tag = ENG
 				tag = ENL
 			}
-			NOT = { 
+			NOT = {
 				government = proletarian_dictatorship
 				government = presidential_dictatorship
 				government = fascist_dictatorship
@@ -1906,12 +1906,12 @@ political_decisions = {
 				NOT = { has_country_flag = agreed_ruperts_land }
 			}
 		}
-		
+
 		allow = {
 			war = no
 			money = 101000
 		}
-		
+
 		effect = {
 			badboy = -3
 			ENG_6 = { remove_core = THIS }
@@ -1940,7 +1940,7 @@ political_decisions = {
 			}
 			CAN = { country_event = 44321 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 #from USCA.txt
@@ -1966,13 +1966,13 @@ political_decisions = {
 			nationalism_n_imperialism = 1
 			NOT = { has_global_flag = treaty_of_managua }
 		}
-		
+
 		allow = {
 			war = no
 			is_greater_power = yes
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			set_global_flag = treaty_of_managua
 			random_country = {
@@ -1992,7 +1992,7 @@ political_decisions = {
 			prestige = 5
 			badboy = -2
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -2090,7 +2090,7 @@ political_decisions = {
 			NOT = { primary_culture = maori }
 			NOT = { has_global_flag = north_island_renamed }
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -2101,7 +2101,7 @@ political_decisions = {
 				year = 1850
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = north_island_renamed
 			2510 = { change_province_name = "New Plymouth" life_rating = 2 }
@@ -2117,13 +2117,13 @@ political_decisions = {
 			any_pop = { limit = { location = { is_core = NZL } culture = australian } reduce_pop = 2.5 }
 			any_pop = { limit = { location = { is_core = NZL } culture = british strata = poor} reduce_pop = 1.8 }
 			any_pop = { limit = { location = { is_core = NZL } culture = maori } literacy = -0.8 reduce_pop = 0.9 }
-			
+
 			any_pop = {
 				limit = { has_pop_culture = maori location = { is_core = NZL } }
 				ideology = { value = reactionary factor = 0.10 }
 				militancy = 3
 			}
-			
+
 			any_owned = {
 				limit = {
 					is_core = NZL
@@ -2137,10 +2137,10 @@ political_decisions = {
 		}
 		ai_will_do = {  factor = 1 }
 	}
-	
+
 	breaking_the_tea_monopoly = {
 		picture = tea_production
-		
+
 		potential = {
 			owns = 1251
 			NOT = { has_global_flag = tea_monopoly_broken }
@@ -2162,13 +2162,13 @@ political_decisions = {
 				}
 			}
 		}
-		
-		
+
+
 		allow = {
 			war = no
-			
+
 		}
-		
+
 		effect = {
 			random_country = { limit = { OR = { tag = CHI tag = QNG } exists = yes } relation = { who = THIS value = -10 } }
 			random_owned = {
@@ -2200,23 +2200,23 @@ political_decisions = {
 					1252 = { trade_goods = tea }
 					1275 = { trade_goods = iron }
 					1515 = { trade_goods = fruit }
-					
+
 					set_global_flag = tea_monopoly_broken
 					clr_global_flag = tea_monopoly_broken_1
 					clr_global_flag = tea_monopoly_broken_2
 					clr_global_flag = tea_monopoly_broken_3
-					
+
 				}
 			}
 			random_owned = {
 				limit = {
 					owner = {
 						has_global_flag = tea_monopoly_broken_2
-						NOT = { 
+						NOT = {
 							has_global_flag = tea_monopoly_broken_3
 							has_global_flag = tea_monopoly_broken
-						} 
-					} 
+						}
+					}
 				}
 				owner = {
 					1297 = { trade_goods = tea }
@@ -2245,15 +2245,15 @@ political_decisions = {
 					set_global_flag = tea_monopoly_broken_3
 				}
 			}
-			
+
 			random_owned = {
 				limit = {
 					owner = {
 						has_global_flag = tea_monopoly_broken_1
-						NOT = { 
+						NOT = {
 							has_global_flag = tea_monopoly_broken_2
 							has_global_flag = tea_monopoly_broken
-						} 
+						}
 					}
 				}
 				owner = {
@@ -2268,7 +2268,7 @@ political_decisions = {
 					set_global_flag = tea_monopoly_broken_2
 				}
 			}
-		
+
 			random_owned = { limit = { owner = { NOT = { has_global_flag = tea_monopoly_broken_1 has_global_flag = tea_monopoly_broken } } }
 				owner = {
 					1258 = { trade_goods = tea }
@@ -2281,10 +2281,10 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from East Indies.txt
 	unite_malaya = {
 		picture = map_east_indies
@@ -2406,7 +2406,7 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	create_malaya = {
 		picture = map_east_indies
 		potential = {
@@ -2734,7 +2734,7 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	north_borneo_company = {
 		picture = map_east_indies
 		potential = {
@@ -2764,7 +2764,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
@@ -2783,7 +2783,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			prestige = 5
 			set_country_flag = north_borneo_company
@@ -2810,11 +2810,11 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
-#from EIC.txt	
+
+#from EIC.txt
 	# government_of_india_act = {
 		# picture = map_india
 		# potential = {
@@ -2838,12 +2838,12 @@ political_decisions = {
 				# country_event = 9990002
 			# }
 		# }
-		
+
 		# ai_will_do = {
 			# factor = 1
 		# }
 	# }
-	
+
 #from England.txt
 	end_of_the_UK = {
 		potential = {
@@ -2859,7 +2859,7 @@ political_decisions = {
 				NOT = { vassal_of = ENG }
 			}
 		}
-	
+
 		allow = {
 			war = no
 			SCO = {
@@ -2871,7 +2871,7 @@ political_decisions = {
 				NOT = { vassal_of = ENG }
 			}
 		}
-	
+
 		effect = {
 			set_global_flag = united_kingdom_no_more
 			ENG_300 = { add_core = ENL }
@@ -2890,14 +2890,14 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	reclaim_the_UK = {
 		picture = reform_the_UK
 		potential = {
 			tag = ENL
 			NOT = { has_country_flag = reclaimed_the_uk }
 		}
-		
+
 		allow = {
 			war = no
 			is_disarmed = no
@@ -2908,7 +2908,7 @@ political_decisions = {
 				war_policy = jingoism
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = reclaimed_the_uk
 			prestige = 10
@@ -2935,14 +2935,14 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	reform_the_UK = {
 		potential = {
 			tag = ENL
 			has_country_flag = reclaimed_the_uk
 			NOT = { exists = ENG }
 		}
-		
+
 		allow = {
 			war = no
 			owns = 300
@@ -2965,7 +2965,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			prestige = 20
 			all_core = {
@@ -3005,7 +3005,7 @@ political_decisions = {
 					ai = no
 				}
 				country_event = 11101
-			}			
+			}
 			any_country = {
 				limit = {
 					in_sphere = THIS
@@ -3032,14 +3032,14 @@ political_decisions = {
 	###British Africa###
 	british_matabale = {
 		picture = "british_somaliland"
-		potential = { 
+		potential = {
 			tag = ENG
 			ai = yes
 			has_global_flag = berlin_conference
 			is_greater_power = yes
 			NOT = { government = proletarian_dictatorship }
 			NOT = { has_country_flag = british_matabale }
-			MAT = { 
+			MAT = {
 				ai = yes
 				civilized = no
 				exists = yes
@@ -3047,13 +3047,13 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			war = no
 			owns = 2076
 			owns = 2087
 		}
-		
+
 		effect = {
 			war = {
 				target = MAT
@@ -3064,10 +3064,10 @@ political_decisions = {
 			}
 			set_country_flag = british_matabale
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from FlavourMod_Africa
 	royal_niger_company = {
 		picture = george_goldie
@@ -3085,7 +3085,7 @@ political_decisions = {
 			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			owns = 1923
 			NOT = { any_greater_power = { war_with = THIS } }
@@ -3098,7 +3098,7 @@ political_decisions = {
 			total_amount_of_ships = 125
 			NOT = { any_greater_power = { war_with = THIS } }
 		}
-		
+
 		effect = {
 			set_country_flag = royal_niger_company
 			badboy = 1
@@ -3129,13 +3129,13 @@ political_decisions = {
 				owner = { diplomatic_influence = { who = SOK value = 400 } }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	niger_coast_protectorate = {
 		picture = "oil_rivers_protectorate"
-		potential = { 
+		potential = {
 			tag = ENG
 			has_global_flag = berlin_conference
 			is_greater_power = yes
@@ -3147,10 +3147,10 @@ political_decisions = {
 				government = absolute_monarchy
 				government = prussian_constitutionalism
 			}
-			NOT = { invention = the_dark_continent } 
+			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			is_disarmed = no
@@ -3162,7 +3162,7 @@ political_decisions = {
 			1932 = { owner = { OR = { tag = THIS in_sphere = THIS } } }
 			1934 = { owner = { OR = { tag = THIS in_sphere = THIS } } }
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = { CLA = { exists = yes ai = yes is_vassal = no } }
@@ -3204,13 +3204,13 @@ political_decisions = {
 			}
 			set_country_flag = niger_coast_protectorate
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	northern_nigeria_protectorate = {
 		picture = "map_africa"
-		potential = { 
+		potential = {
 			tag = ENG
 			has_global_flag = berlin_conference
 			is_greater_power = yes
@@ -3236,14 +3236,14 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			is_disarmed = no
 			blue_and_brown_water_schools = 1
 			invention = colonial_negotiations
 		}
-		
+
 		effect = {
 			random_country = {
 				limit = {
@@ -3256,13 +3256,13 @@ political_decisions = {
 			}
 			set_country_flag = northern_nigeria_protectorate
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	fourth_ashanti_war = {
 		picture = "map_ghana"
-		potential = { 
+		potential = {
 			tag = ENG
 			has_global_flag = berlin_conference
 			is_greater_power = yes
@@ -3287,7 +3287,7 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			is_disarmed = no
@@ -3295,7 +3295,7 @@ political_decisions = {
 			invention = colonial_negotiations
 			total_amount_of_ships = 125
 		}
-		
+
 		effect = {
 			diplomatic_influence = { who = ASH value = -400 }
 			random_country = {
@@ -3316,10 +3316,10 @@ political_decisions = {
 			}
 			set_country_flag = fourth_ashanti_war
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	###British East Africa
 	zanzibar_protectorate = {
 		picture = zanzibar_protectorate
@@ -3329,10 +3329,10 @@ political_decisions = {
 			year = 1896
 			is_greater_power = yes
 			has_country_flag = treaty_of_heligoland_success
-			NOT = { has_country_flag = zanzibar_protectorate } 
+			NOT = { has_country_flag = zanzibar_protectorate }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			war = no
 			ZAN = {
@@ -3340,23 +3340,23 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = zanzibar_protectorate
 			badboy = 1
 			prestige = 5
 			inherit = ZAN
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	british_east_africa = {
 		picture = british_east_africa
 		potential = {
 			tag = ENG
 			owns = 2029
-			OR = { 
+			OR = {
 				has_country_flag = treaty_of_heligoland_success
 				AND = {
 					owns = 2036
@@ -3364,15 +3364,15 @@ political_decisions = {
 					owns = 2024
 				}
 			}
-			NOT = { has_country_flag = british_east_africa } 
+			NOT = { has_country_flag = british_east_africa }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			owns = 2029
 			is_greater_power = yes
 		}
-		
+
 		effect = {
 			set_country_flag = british_east_africa
 			2024 = { secede_province = ENG any_pop = { literacy = -0.99 } }
@@ -3394,13 +3394,13 @@ political_decisions = {
 			}
 			KNY = { government = colonial_company }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	british_somaliland = {
 		picture = "british_somaliland"
-		potential = { 
+		potential = {
 			tag = ENG
 			has_global_flag = berlin_conference
 			is_greater_power = yes
@@ -3418,10 +3418,10 @@ political_decisions = {
 					is_vassal = no
 					vassal_of = THIS
 				}
-			} 
+			}
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			is_greater_power = yes
@@ -3431,7 +3431,7 @@ political_decisions = {
 			money = 35001
 			owns = 1412
 		}
-		
+
 		effect = {
 			prestige = 5
 			treasury = -35000
@@ -3443,20 +3443,20 @@ political_decisions = {
 			set_country_flag = british_somaliland
 		}
 	}
-	
+
 	british_sierra_leone = {
 		picture = "rhodesia_renaming_act"
-		potential = { 
+		potential = {
 			tag = ENG
 			has_global_flag = berlin_conference
 			is_greater_power = yes
 			NOT = { government = proletarian_dictatorship }
 			NOT = { has_country_flag = british_sierra_leone }
 			owns = 1884
-			1885 = { empty = yes } 
+			1885 = { empty = yes }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			total_pops = 2000000
@@ -3467,7 +3467,7 @@ political_decisions = {
 			owns = 1884
 			money = 55001
 		}
-		
+
 		effect = {
 			prestige = 5
 			money = 55000
@@ -3475,12 +3475,12 @@ political_decisions = {
 			1886 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			set_country_flag = british_sierra_leone
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 	eng_ai_annex_egypt = {
 		picture = "suezcanal"
-		potential = { 
+		potential = {
 			capital_scope = { continent = europe }
 			is_greater_power = yes
 			owns = 1755
@@ -3505,18 +3505,18 @@ political_decisions = {
 				}
 				AND = {
 					EGY = { vassal_of = TUR }
-					TUR = { 
+					TUR = {
 						is_greater_power = no
 						ai = yes
 					}
 				}
 			}
 		}
-		
+
 		effect = {
 			leave_alliance = EGY
 			diplomatic_influence = {
-				who = EGY 
+				who = EGY
 				value = -400
 			}
 			casus_belli = {
@@ -3526,13 +3526,13 @@ political_decisions = {
 			}
 			war = {
 				target = EGY
-				attacker_goal = { casus_belli = annex_africa_full }		
+				attacker_goal = { casus_belli = annex_africa_full }
 				defender_goal = { casus_belli = status_quo }
-			}	
+			}
 			set_country_flag = ai_annex_egypt
 		}
 	}
-		
+
 	form_kingdom_of_egypt = {
 		picture = "egyptian_constitution"
 		potential = {
@@ -3547,14 +3547,14 @@ political_decisions = {
 				EGY = {
 					all_core = {
 						owned_by = THIS
-					}	
+					}
 				}
 				EGY = { vassal_of = THIS }
 			}
 			year = 1900
 			NOT = { has_global_flag = form_kingdom_of_egypt }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			mass_politics = 1
@@ -3562,7 +3562,7 @@ political_decisions = {
 				EGY = {
 					all_core = {
 						owned_by = THIS
-					}	
+					}
 				}
 				EGY = { vassal_of = THIS }
 			}
@@ -3576,7 +3576,7 @@ political_decisions = {
 				year = 1919
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = form_kingdom_of_egypt
 			badboy = -8
@@ -3598,12 +3598,12 @@ political_decisions = {
 				political_reform = appointed
 				political_reform = no_slavery
 				plurality = -5
-				
+
 				any_owned = {
 					limit = { is_core = SUD }
 					secede_province = THIS
 				}
-				
+
 				random_owned = {
 					limit = { province_id = 1755 }
 					secede_province = THIS
@@ -3620,10 +3620,10 @@ political_decisions = {
 			}
 			create_alliance = EGY
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from FlavourMod_EIC.txt
 	government_of_india_act = {
 		picture = map_india
@@ -3659,7 +3659,7 @@ political_decisions = {
 
 		allow = {
 			war = no
-			
+
 		}
 
 		effect = {
@@ -3677,7 +3677,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	anglo_afghan_war = {
 		picture = george_eden
 		potential = {
@@ -3703,17 +3703,17 @@ political_decisions = {
 		}
 
 		allow = {
-			ENG = { 
+			ENG = {
 				war = no
 				NOT = { truce_with = AFG }
 			}
 			AFG = {
-				OR = { 
+				OR = {
 					neighbour = EIC
 					neighbour = ENG
 				}
-				NOT = { 
-					relation = { who = ENG value = 150 } 
+				NOT = {
+					relation = { who = ENG value = 150 }
 					alliance_with = ENG
 				}
 				any_neighbor_country = { vassal_of = ENG }
@@ -3724,13 +3724,13 @@ political_decisions = {
 			set_country_flag = anglo_afghan_war
 			ENG = { country_event = 99100 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	india_penal_code = {
 		picture = "india_penal_code"
-		potential = { 
+		potential = {
 			OR = {
 				AND = {
 					tag = ENG
@@ -3743,7 +3743,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = india_penal_code }
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
@@ -3755,7 +3755,7 @@ political_decisions = {
 			owns = 1297
 			owns = 1227
 		}
-		
+
 		effect = {
 			set_country_flag = india_penal_code
 			prestige = 5
@@ -3771,13 +3771,13 @@ political_decisions = {
 				economic_reform = yes_admin_reform
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	india_civil_service = {
 		picture = "india_civil_service"
-		potential = { 
+		potential = {
 			OR = {
 				AND = {
 					tag = ENG
@@ -3790,7 +3790,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = india_civil_service }
 		}
-		
+
 		allow = {
 			money = 80100
 			war = no
@@ -3803,7 +3803,7 @@ political_decisions = {
 			owns = 1297
 			owns = 1227
 		}
-		
+
 		effect = {
 			set_country_flag = india_civil_service
 			treasury = -80000
@@ -3821,7 +3821,7 @@ political_decisions = {
 				limit = { owner = { NOT = { capital_scope = { continent = europe } } } }
 				owner = {
 					any_pop = {
-						limit = { 
+						limit = {
 							culture = british
 							type = bureaucrats
 							location = { is_core = HND }
@@ -3829,7 +3829,7 @@ political_decisions = {
 						reduce_pop = 2
 					}
 					any_pop = {
-						limit = { 
+						limit = {
 							culture = anglo_indian
 							type = bureaucrats
 							location = { is_core = HND }
@@ -3839,17 +3839,17 @@ political_decisions = {
 				}
 			}
 			any_pop = {
-				limit = { 
+				limit = {
 					culture = anglo_indian
 					location = { is_core = HND }
 				}
 				reduce_pop = 1.25
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	new_dehli_renovation = {
 		picture = new_dehli_renovation
 		potential = {
@@ -3883,27 +3883,27 @@ political_decisions = {
 			prestige = 15
 			money = -100000
 			1236 = {
-				life_rating = 6 
+				life_rating = 6
 				add_province_modifier = {
 					name = recently_built_city
 					duration = 720
 				}
-				
+
 			}
-			HND = { 
+			HND = {
 				capital = 1236
 			}
 			set_country_flag = new_dehli_renovation
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	begin_pax_britannica = {
 		picture = "pax_britannica"
-		potential = { 
+		potential = {
 			tag = ENG
 			year = 1836
 			has_global_flag = yes_isolation
@@ -3925,7 +3925,7 @@ political_decisions = {
 
 	singapore_strategy = {
 		picture = "fortress_singapore"
-		potential = { 
+		potential = {
 			is_greater_power = yes
 			year = 1900
 			owns = 1384
@@ -3943,18 +3943,18 @@ political_decisions = {
 			}
 			war = no
 		}
-		
+
 		effect = {
 			treasury = -150000
 			1384 = { naval_base = 6}
 			1384 = { fort = 5}
 			set_country_flag = singapore_strategy
 		}
-	}	
-	
+	}
+
 	british_imperial_airways = {
 		picture = "imperial_airways"
-		potential = { 
+		potential = {
 			tag = ENG
 			is_greater_power = yes
 			year = 1920
@@ -3966,13 +3966,13 @@ political_decisions = {
 			aeronautics = 1
 			war = no
 		}
-		
+
 		effect = {
 			prestige = 50
 			treasury = -150000
 			set_country_flag = imperial_airways
 		}
-	}	
+	}
 
 	found_suez_canal_company_eng_ai = {
 		picture = suezcanal
@@ -3986,7 +3986,7 @@ political_decisions = {
 			1755 = {
 				owner = {
 					OR = {
-						part_of_sphere = no 
+						part_of_sphere = no
 						in_sphere = THIS
 					}
 				}
@@ -3994,15 +3994,15 @@ political_decisions = {
 			year = 1875
 			tag = ENG
 		}
-		
+
 		allow = {
 			invention = machine_tools
-			invention = nitroglycerin		
+			invention = nitroglycerin
 			iron_steamers = 1
 			money = 50100
 			1755 = { owner = { NOT = { truce_with = THIS war_with = THIS is_greater_power = yes } } }
 		}
-		
+
 		effect = {
 			set_global_flag = suez_canal_company_founded_backup
 			prestige = 5
@@ -4010,10 +4010,10 @@ political_decisions = {
 			diplomatic_influence = { who = EGY value = 100 }
 			1755 = { owner = { relation = { who = THIS value = 75 } country_event = 36981 } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	the_irish_dominion = {
 		picture = ireland
 		potential = {
@@ -4035,11 +4035,11 @@ political_decisions = {
 			#NOT = { has_global_flag = irish_war_of_independence }
 			NOT = { has_country_flag = the_irish_dominion }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			set_country_flag = the_irish_dominion
 			prestige = 5
@@ -4047,22 +4047,22 @@ political_decisions = {
 				government = colonial_company
 				add_accepted_culture = british
 				any_owned = {
-					limit = { region = ENG_254 
+					limit = { region = ENG_254
 					not = { province_id = 257 }
-					not = { province_id = 3349 } 
+					not = { province_id = 3349 }
 					}
 					add_core = THIS
 					secede_province = THIS
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	break_alliance_AI = {
 		picture = "pax_britannica"
-		potential = { 
+		potential = {
 			tag = ENG
 			NOT = { exists = IRE }
 			ai = yes
@@ -4081,7 +4081,7 @@ political_decisions = {
 				AND = {
 					EGY = { war_with = TUR }
 					war_with = EGY
-					OR = { 
+					OR = {
 						war_with = FRA
 						war_with = BOR
 					}
@@ -4116,11 +4116,11 @@ political_decisions = {
 				POR = { is_greater_power = no }
 			}
 		}
-		
+
 		effect = {
 			any_greater_power = {
 				limit = {
-					NOT = { 
+					NOT = {
 						tag = JAP
 						tag = BEL
 						tag = TUR
@@ -4134,23 +4134,23 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	ric_reorganize = {
 		picture = "ric_police"
-		potential = { 
+		potential = {
 			tag = ENG
 			NOT = { has_country_flag = ric_reorganized }
 		}
-		
+
 		allow = { war = no }
-		
+
 		effect = {
 			set_country_flag = ric_reorganized
 			any_owned = {
-				limit = { 
+				limit = {
 					OR = {
 						province_id = 254
 						province_id = 255
@@ -4170,10 +4170,10 @@ political_decisions = {
 				add_province_modifier = { name = royal_irish_constabulary duration = -1 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	organize_west_indies = {
 		picture = map_caribbean
 		potential = {
@@ -4196,7 +4196,7 @@ political_decisions = {
 					government = hms_government
 					NOT = { has_global_flag = british_dismantled }
 					has_global_flag = france_dismantled
-					OR = { 
+					OR = {
 						FRA = { government = proletarian_dictatorship }
 						BOR = { government = proletarian_dictatorship }
 					}
@@ -4206,12 +4206,12 @@ political_decisions = {
 			2217 = { owned_by = ENG }
 			NOT = { has_global_flag = caribbean_federation_formed }
 		}
-		
+
 		allow = {
 			war = no
 			2217 = { owned_by = ENG }
 		}
-		
+
 		effect = {
 			set_global_flag = caribbean_federation_formed
 			prestige = 3
@@ -4238,7 +4238,7 @@ political_decisions = {
 				limit = {
 					primary_culture = french
 					capital = 425
-				}	
+				}
 				country_event = 99992
 			}
 			CRB = {
@@ -4250,7 +4250,7 @@ political_decisions = {
 			release_vassal = CRB
 		}
 	}
-	
+
 	ai_get_british_wyoming = {
 		potential = {
 			tag = ENG
@@ -4259,20 +4259,20 @@ political_decisions = {
 			USA = { ai = yes }
 			NOT = { has_country_flag = ai_get_british_wyoming }
 		}
-		
+
 		allow = { war = no }
-		
+
 		effect = {
 			set_country_flag = ai_get_british_wyoming
 			111 = { secede_province = ENG }
 			COL = {  all_core = { remove_core = ENG } }
 			RPL = { any_owned = { limit = { is_core = COL } secede_province = ENG } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
-		
+
 	landship_committee = {
 		picture = landship
 		potential = {
@@ -4283,22 +4283,22 @@ political_decisions = {
 			invention = tank_experiments
 			NOT = { 284 = { state_scope = { has_building = barrel_factory } } }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			invention = tank_experiments
 			is_disarmed = no
 			money = 31000
 		}
-		
+
 		effect = {
 			treasury = -30000
 			random_owned = {
 				limit = {
 					province_id = 284
 					state_scope = { NOT = { has_building = barrel_factory } }
-				}		
-				owner = { 
+				}
+				owner = {
 					capital = 284
 					build_factory_in_capital_state = barrel_factory
 				}
@@ -4309,10 +4309,10 @@ political_decisions = {
 			}
 			set_global_flag = landship_committee
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	royal_aircraft_factory = {
 		picture = royal_aircraft_factory
 		potential = {
@@ -4322,14 +4322,14 @@ political_decisions = {
 			aeronautics = 1
 			NOT = { 297 = { state_scope = { has_building = aeroplane_factory } } }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			invention = wright_n_langleys_aeroplanes
 			is_disarmed = no
 			money = 31000
 		}
-		
+
 		effect = {
 			set_global_flag = royal_aircraft_factory
 			treasury = -30000
@@ -4338,8 +4338,8 @@ political_decisions = {
 					province_id = 297
 					state_scope = { NOT = { has_building = aeroplane_factory } }
 				}
-				
-				owner = { 
+
+				owner = {
 					capital = 297
 					build_factory_in_capital_state = aeroplane_factory
 				}
@@ -4349,16 +4349,16 @@ political_decisions = {
 				THIS = { capital = 300 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	brunei_protectorate = {
 		picture = brunei_protectorate
 		potential = {
 			OR = {
 				SWK = { any_core = { owned_by = THIS } }
-				JOH = { any_core = { owned_by = THIS } }	
+				JOH = { any_core = { owned_by = THIS } }
 				INO = { any_core = { owned_by = THIS } }
 				MLY = { any_core = { owned_by = THIS } }
 				JAV = { any_core = { owned_by = THIS } }
@@ -4369,13 +4369,13 @@ political_decisions = {
 				government = hms_government
 			}
 			OR = {
-				SWK = { 
-					all_core = { 
-						OR = { 
-							owned_by = THIS 
+				SWK = {
+					all_core = {
+						OR = {
+							owned_by = THIS
 							owner = { in_sphere = THIS }
-						} 
-					} 
+						}
+					}
 				}
 				owns = 1395
 			}
@@ -4394,7 +4394,7 @@ political_decisions = {
 			relation = {
 				who = BRU
 				value = 150
-			}		
+			}
 			diplomatic_influence = {
 				who = BRU
 				value = 400
@@ -4402,12 +4402,12 @@ political_decisions = {
 			create_vassal = BRU
 			set_country_flag = brunei_protectorate
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	purchase_alaska = {
 		picture = map_alaska
 		potential = {
@@ -4428,11 +4428,11 @@ political_decisions = {
 					RUS = { owns = 1 }
 					OR = {
 						owns = 13
-						RPL = { 
+						RPL = {
 							vassal_of = ENG
 							owns = 13
 						}
-						COL = { 
+						COL = {
 							vassal_of = ENG
 							owns = 13
 						}
@@ -4444,20 +4444,20 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			set_country_flag = alaska_purchase_interest
 			set_country_flag = purchase_alaska_interest
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	maldives_protectorate = {
 		picture = maldives_protectorate
 		potential = {
@@ -4476,10 +4476,10 @@ political_decisions = {
 			create_vassal = MLD
 			set_country_flag = maldives_protectorate
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	papua_colony = {
 		picture = papua_act
 		potential = {
@@ -4513,8 +4513,8 @@ political_decisions = {
 			2529 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			2528 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 		}
-		
-		ai_will_do = { 
+
+		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
@@ -4522,22 +4522,22 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	papua_act = {
 		picture = papua_act
 		potential = {
 			tag = ENG
 			OR = {
-				AND = { 
+				AND = {
 					owns = 2528
 					owns = 2529
 					NOT = { has_country_flag = papua_act_south }
 				}
-				AND = { 
+				AND = {
 					owns = 2530
 					NOT = { has_country_flag = papua_act_north }
 				}
-				AND = { 
+				AND = {
 					owns = 2534
 					NOT = { has_country_flag = papua_act_solomons }
 				}
@@ -4562,12 +4562,12 @@ political_decisions = {
 		effect = {
 			random_owned = {
 				limit = { region = AST_2528 }
-				owner = { 
+				owner = {
 					any_owned = {
 						limit = { region = AST_2528 }
 						secede_province = AST
-					} 
-					badboy = -2 set_country_flag = papua_act_south 
+					}
+					badboy = -2 set_country_flag = papua_act_south
 				}
 			}
 			random_owned = {
@@ -4577,7 +4577,7 @@ political_decisions = {
 						limit = { region = GER_2530 }
 						secede_province = AST
 					}
-					badboy = -2 set_country_flag = papua_act_north 
+					badboy = -2 set_country_flag = papua_act_north
 				}
 				PPG = { government = hms_government }
 			}
@@ -4588,20 +4588,20 @@ political_decisions = {
 						limit = { region = AST_2534 }
 						secede_province = AST
 					}
-					badboy = -1 set_country_flag = papua_act_solomons 
+					badboy = -1 set_country_flag = papua_act_solomons
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	jamaican_crown_colony = {
 		picture = map_caribbean
 		potential = {
 			has_global_flag = morant_bay_rebellion
-			JAM = { 
-				vassal_of = THIS 
+			JAM = {
+				vassal_of = THIS
 				exists = yes
 			}
 			NOT = { has_country_flag = jamaican_crown_colony }
@@ -4616,21 +4616,21 @@ political_decisions = {
 			inherit = JAM
 			2217 = {
 				any_pop = {
-					limit = { has_pop_culture = afro_caribbean }		
+					limit = { has_pop_culture = afro_caribbean }
 					militancy = 5
 				}
 			}
-			JAM = { 
+			JAM = {
 				primary_culture = british
 				add_accepted_culture = kreol
 				add_accepted_culture = afro_caribbean
 			}
 			set_country_flag = jamaican_crown_colony
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	mosquito_protectorate = {
 		picture = moskito_coast_reserve
 		potential = {
@@ -4651,8 +4651,8 @@ political_decisions = {
 
 		effect = {
 			create_vassal = MSK
-			random_country = { 
-				limit = { 
+			random_country = {
+				limit = {
 					OR = {
 						primary_culture = central_american
 						primary_culture = spanish
@@ -4664,10 +4664,10 @@ political_decisions = {
 			}
 			set_country_flag = mosquito_protectorate
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	sovereign_base_area_cyprus = {
 		picture = sovereign_base_area
 		potential = {
@@ -4693,10 +4693,10 @@ political_decisions = {
 		effect = {
 			treasury = -3500
 			badboy = 0.5
-			2690 = { 
-				secede_province = ENG 
-				add_core = ENG 
-				any_pop = { militancy = 5 }	
+			2690 = {
+				secede_province = ENG
+				add_core = ENG
+				any_pop = { militancy = 5 }
 				naval_base = 1
 			}
 			CYP = { any_pop = { militancy = 5 } }
@@ -4706,7 +4706,7 @@ political_decisions = {
 			}
 			set_country_flag = sovereign_base_area_cyprus
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 #from FlavourMod_GreatGame.txt
@@ -4725,12 +4725,12 @@ political_decisions = {
 				}
 				PER = {
 					truce_with = THIS
-					has_recently_lost_war = yes 
+					has_recently_lost_war = yes
 				}
 			}
 			NOT = { has_country_flag = treaty_of_paris_anglo_persian }
 		}
-		
+
 		allow = {
 			OR = {
 				PER = {
@@ -4742,24 +4742,24 @@ political_decisions = {
 				}
 				PER = {
 					truce_with = THIS
-					has_recently_lost_war = yes 
+					has_recently_lost_war = yes
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = treaty_of_paris_anglo_persian
 			prestige = 15
 			badboy = -3
 			PER = { country_event = 99204 }
-			relation = { 
+			relation = {
 				who = AFG
 				value = 100
 			}
 			#Secede Qeshm to Oman
 			random_owned = {
-				limit = { 
-					province_id = 1071 
+				limit = {
+					province_id = 1071
 					OMA = { exists = yes in_sphere = THIS }
 				}
 				secede_province = OMA
@@ -4773,7 +4773,7 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	gwadar_treaty = {
 		picture = gwadar_pakistan
 		potential = {
@@ -4802,22 +4802,22 @@ political_decisions = {
 			invention = the_dark_continent
 			NOT = { has_global_flag = gwadar_treaty }
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 			is_greater_power = yes
 		}
-		
+
 		effect = {
 			set_global_flag = gwadar_treaty
 			prestige = 5
 			2640 = { secede_province = THIS add_core = HND }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	wakhan_treaty = {
 		picture = "wakhan_treaty"
 		potential = {
@@ -4836,22 +4836,22 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = wakhan_treaty }
 		}
-		
+
 		allow = {
 			state_n_government = 1
 			war = no
 			NOT = { truce_with = RUS }
 			NOT = { truce_with = AFG }
 		}
-		
+
 		effect = {
 			set_global_flag = wakhan_treaty
 			RUS = { country_event = 99103 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	persia_treaty = {
 		picture = "persia_map"
 		potential = {
@@ -4860,7 +4860,7 @@ political_decisions = {
 			is_disarmed = no
 			OR = {
 				PER = { vassal_of = RUS }
-				1149 = { owned_by = RUS } 
+				1149 = { owned_by = RUS }
 				1108 = { owned_by = RUS }
 				1113 = { owned_by = RUS }
 				1142 = { owned_by = RUS }
@@ -4873,22 +4873,22 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = persia_treaty }
 		}
-		
+
 		allow = {
 			state_n_government = 1
 			war = no
 			NOT = { truce_with = RUS }
 			NOT = { truce_with = PER }
 		}
-		
+
 		effect = {
 			set_global_flag = persia_treaty
 			RUS = { country_event = 99104 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	oman_protectorate = {
 		picture = map_arabia
 		potential = {
@@ -4909,7 +4909,7 @@ political_decisions = {
 			nationalism_n_imperialism = 1
 			NOT = { has_global_flag = created_oman_protectorate }
 		}
-		
+
 		allow = {
 			war = no
 			OMA = {
@@ -4919,13 +4919,13 @@ political_decisions = {
 			invention = the_dark_continent
 			invention = colonial_negotiations
 		}
-		
+
 		effect = {
 			set_global_flag = created_oman_protectorate
 			prestige = 5
 			create_vassal = OMA
 			relation = { who = OMA value = 200 }
-			
+
 			random_owned = { limit = { exists = NEJ } owner = { diplomatic_influence = { who = NEJ value = 50 } } }
 			random_owned = { limit = { exists = HAL } owner = { diplomatic_influence = { who = HAL value = 50 } } }
 			random_owned = { limit = { exists = BHR } owner = { diplomatic_influence = { who = BHR value = 50 } } }
@@ -4937,7 +4937,7 @@ political_decisions = {
 #from FlavourMod_MiddleEast.txt
 	sykes_picot_agreement_no_great_war = { #Carve up the Ottoman Empire without a Great War
 		picture = "sykes_picot"
-		potential = { 
+		potential = {
 			tag = ENG
 			is_disarmed = no
 			OR = {
@@ -4955,14 +4955,14 @@ political_decisions = {
 				owns = 902
 				owns = 897
 			}
-			OR = { 
+			OR = {
 				relation = { who = FRA value = 100 }
 				relation = { who = BOR value = 100 }
 			}
 			NOT = { has_global_flag = sykes_picot }
 			NOT = { year = 1900 }
 		}
-		
+
 		allow = {
 			TUR = {
 				part_of_sphere = no
@@ -4975,13 +4975,13 @@ political_decisions = {
 			is_greater_power = yes
 			revolution_n_counterrevolution = 1
 			OR = {
-				FRA = { 
+				FRA = {
 					exists = yes
 					alliance_with = THIS
 					war = no
 					NOT = { truce_with = THIS }
 				}
-				BOR = { 
+				BOR = {
 					exists = yes
 					alliance_with = THIS
 					war = no
@@ -4989,7 +4989,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = sykes_picot_agreed
 			set_global_flag = sykes_picot
@@ -5002,18 +5002,18 @@ political_decisions = {
 						religion = shiite
 					}
 				}
-				consciousness = 8	
+				consciousness = 8
 				militancy = 8
 			}
 			random_country = {
 				limit = {
 					primary_culture = french
 					capital = 425
-				}	
+				}
 				country_event = 99972
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -5022,10 +5022,10 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	the_asia_minor_agreement = { #Carve up the Ottoman Empire without a Great War - Without France as Ally
 		picture = "sykes_picot"
-		potential = { 
+		potential = {
 			tag = ENG
 			is_disarmed = no
 			OR = {
@@ -5046,14 +5046,14 @@ political_decisions = {
 			OR = {
 				FRA = { exists = yes NOT = { alliance_with = ENG } }
 				BOR = { exists = yes NOT = { alliance_with = ENG } }
-			}				
+			}
 			NOT = { RUS = { is_greater_power = yes alliance_with = THIS } }
 			NOT = { has_global_flag = sykes_picot }
 			NOT = { year = 1900 }
 		}
-		
+
 		allow = {
-			any_greater_power = { 
+			any_greater_power = {
 				NOT = { tag = JAP }
 				NOT = { tag = USA }
 				alliance_with = ENG
@@ -5063,7 +5063,7 @@ political_decisions = {
 			is_greater_power = yes
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		effect = {
 			set_country_flag = sykes_picot_agreed
 			set_global_flag = sykes_picot
@@ -5076,7 +5076,7 @@ political_decisions = {
 						religion = shiite
 					}
 				}
-				consciousness = 8	
+				consciousness = 8
 				militancy = 8
 			}
 			any_greater_power = {
@@ -5084,7 +5084,7 @@ political_decisions = {
 				country_event = 99972
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -5093,11 +5093,11 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	return_adana_to_turkey = {
 		picture = christian_question_armenia
 		potential = {
-			NOT = { 
+			NOT = {
 				primary_culture = turkish
 				primary_culture = greek
 				primary_culture = armenian
@@ -5106,12 +5106,12 @@ political_decisions = {
 			has_country_flag = sykes_picot_agreed
 			NOT = { has_country_flag = return_adana_to_turkey }
 		}
-		
+
 		allow = {
 			war = no
 			mass_politics = 1
 		}
-		
+
 		effect = {
 			set_country_flag = return_adana_to_turkey
 			badboy = -3
@@ -5128,10 +5128,10 @@ political_decisions = {
 				value = 150
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	anglo_kuwait_treaty = {
 		picture = bahrain_trade
 		potential = {
@@ -5150,14 +5150,14 @@ political_decisions = {
 			nationalism_n_imperialism = 1
 			NOT = { has_country_flag = anglo_kuwait_treaty }
 		}
-		
+
 		allow = {
 			war = no
 			has_recently_lost_war = no
 			is_greater_power = yes
 			war_policy = jingoism
 		}
-		
+
 		effect = {
 			set_country_flag = anglo_kuwait_treaty
 			relation = {
@@ -5170,7 +5170,7 @@ political_decisions = {
 			}
 			create_vassal = KWT
 		}
-		
+
 		ai_will_do = { factor = 1  }
 	}
 #from NET.txt
@@ -5187,7 +5187,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = mediated_belgian_independence }
 		}
-		
+
 		allow = {
 			NET = {
 				war = no
@@ -5196,7 +5196,7 @@ political_decisions = {
 			BEL = {
 				war = no
 			}
-			OR = { 
+			OR = {
 				relation = {
 					who = NET
 					value = 100
@@ -5207,13 +5207,13 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = mediated_belgian_independence
 			prestige = 10
 			NET = { country_event = 36709 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -5222,7 +5222,7 @@ political_decisions = {
 			}
 		}
 	}
-#from FlavourMod_Qing	
+#from FlavourMod_Qing
 	weihaiwei_treaty_port_eng = {
 		picture = "weihaiwei_china"
 		potential = {
@@ -5236,13 +5236,14 @@ political_decisions = {
 			}
 			1569 = { owner = { civilized = no NOT = { war_with = THIS } } }
 			NOT = { has_country_flag = weihaiwei_treaty_port_eng }
+			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			steel_steamers = 1
 			1569 = { owner = { civilized = no } }
 		}
-		
+
 		effect = {
 			set_country_flag = weihaiwei_treaty_port_eng
 			1569 = { secede_province = THIS change_controller = THIS }
@@ -5257,16 +5258,16 @@ political_decisions = {
 		potential = {
 			tag = ENG
 			has_global_flag = second_opium_war
-			has_country_modifier = negotiating_treaty	
+			has_country_modifier = negotiating_treaty
 			NOT = { owns = 1538 }
 			1538 = { owner  = { has_country_modifier = negotiating_unequal_treaty tag = QNG } }
 			QNG = { exists = yes truce_with = THIS }
 			NOT = { has_country_modifier = chinese_treaty_port }
 			NOT = { has_global_flag = second_opium_war_treaty }
 		}
-		
+
 		allow = { NOT = { war_with = QNG } }
-		
+
 		effect = {
 			prestige = 10
 			badboy = -3
@@ -5277,7 +5278,7 @@ political_decisions = {
 				life_rating = 3
 				secede_province = QNG
 				remove_core = TPG
-				trade_goods = precious_goods 
+				trade_goods = precious_goods
 				add_province_modifier = {
 					name = western_presence
 					duration = -1
@@ -5309,7 +5310,7 @@ political_decisions = {
 			}
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 				modifier = {
@@ -5325,7 +5326,7 @@ political_decisions = {
 			tag = ENG
 			ai = yes
 			war = yes
-			OR = { 
+			OR = {
 				EIC = {
 					OR = {
 						vassal_of = ENG
@@ -5343,10 +5344,10 @@ political_decisions = {
 				}
 			}
 		}
-		
-		allow = { 
+
+		allow = {
 			OR = {
-				AND = { 
+				AND = {
 					any_greater_power = { war_with = ENG NOT = { war_with = EIC } }
 					EIC = {
 						OR = {
@@ -5357,7 +5358,7 @@ political_decisions = {
 						war = no
 					}
 				}
-				AND = { 
+				AND = {
 					any_neighbor_country = { war_with = ENG NOT = { war_with = EIC } }
 					EIC = {
 						OR = {
@@ -5393,9 +5394,9 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
-			   war = {               #No target initiates a one-day war that automatically resolves in a WP, but call_ally causes the new ally 
+			   war = {               #No target initiates a one-day war that automatically resolves in a WP, but call_ally causes the new ally
 				   attacker_goal = {  casus_belli = call_allies_cb  }
 				   call_ally = yes
 			   }
@@ -5448,9 +5449,9 @@ political_decisions = {
 				# add_core = COL
 				# add_core = CAN
 				# remove_core = RPL
-			# }	
+			# }
 			# #Remove RPL & USA Cores, if owned
-			# RPL = {			
+			# RPL = {
 				# any_owned = {
 					# limit = {
 						# OR = {
@@ -5632,8 +5633,8 @@ political_decisions = {
 				}
 				country_event = 11101
 			}
-			RAJ = { 
-				tech_school = unciv_tech_school 
+			RAJ = {
+				tech_school = unciv_tech_school
 				political_reform = regionalism
 				activate_technology = post_napoleonic_thought
 				activate_technology = flintlock_rifles
@@ -5645,7 +5646,7 @@ political_decisions = {
 				activate_technology = early_railroad
 				activate_technology = piston_steam_engine
 				activate_technology = freedom_of_trade
-				
+
 			}
 			RAJ = {
 				civilized = yes
@@ -5667,19 +5668,19 @@ political_decisions = {
 				create_vassal = RAJ
 			}
 			any_pop = {
-				limit = { 
+				limit = {
 					location = { is_core = HND }
 				}
 				militancy = -3
 				consciousness = -3
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	form_baluchistan_agency = {
 		picture = form_baluchistan
         potential = {
@@ -5776,7 +5777,7 @@ political_decisions = {
 			1221 = { secede_province = BLC }
 			1222 = { secede_province = BLC }
 			3258 = { secede_province = BLC }
-			random_owned = { 
+			random_owned = {
 				limit = {
 					province_id = 1144
 					NOT = { is_core = PER }
@@ -5785,8 +5786,8 @@ political_decisions = {
 			}
 			create_vassal = BLC
 			diplomatic_influence = { who = BLC value = 400 }
-			BLC = { 
-				tech_school = unciv_tech_school 
+			BLC = {
+				tech_school = unciv_tech_school
 				political_reform = regionalism
 				activate_technology = post_napoleonic_thought
 				activate_technology = flintlock_rifles
@@ -5799,7 +5800,7 @@ political_decisions = {
 				activate_technology = piston_steam_engine
 				activate_technology = freedom_of_trade
 			}
-			BLC = { 
+			BLC = {
 				civilized = yes
 				military_access = ENG
 				government = colonial_company
@@ -5807,7 +5808,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	form_central_india_agency = {
 	picture = map_india
         potential = {
@@ -5856,7 +5857,7 @@ political_decisions = {
 					owner = { vassal_of = THIS }
 				}
 			}
-			
+
 		}
 
 		effect = {
@@ -5903,11 +5904,11 @@ political_decisions = {
 			1282 = { secede_province = BUN add_core = BUN }
 			create_vassal = BUN
 			diplomatic_influence = { who = BUN value = 400 }
-			BUN = { 
+			BUN = {
 				add_accepted_culture = marathi
 				political_reform = regionalism
 				capital = 1271
-				tech_school = unciv_tech_school 
+				tech_school = unciv_tech_school
 				activate_technology = post_napoleonic_thought
 				activate_technology = flintlock_rifles
 				activate_technology = muzzle_loaded_rifles
@@ -5919,7 +5920,7 @@ political_decisions = {
 				activate_technology = piston_steam_engine
 				activate_technology = freedom_of_trade
 			}
-			BUN = { 
+			BUN = {
 				civilized = yes
 				military_access = ENG
 				government = colonial_company
@@ -5927,7 +5928,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	#Aberdeen Act for UK
 	# aberdeen_act = {
 		# potential = {
@@ -5953,7 +5954,7 @@ political_decisions = {
 			# }
 		# }
 	# }
-	USA_CAN_denied = { 
+	USA_CAN_denied = {
 		picture = canadian_dominion
 		potential = {
 			tag = ENG
@@ -5995,16 +5996,16 @@ political_decisions = {
 			USA_81 = { add_core = ENG }
 			USA_81 = { add_core = COL }
 			USA_91 = { add_core = ENG }
-			USA_91 = { add_core = COL }			
+			USA_91 = { add_core = COL }
 			COL = {
-				primary_culture = anglo_canadian 
+				primary_culture = anglo_canadian
 				add_accepted_culture = yankee
 			}
 			USA = {
 				any_owned = {
-					limit = { 
+					limit = {
 						OR = {
-							is_core = NEN 
+							is_core = NEN
 							is_core = ENG
 							is_core = CAN
 							is_core = COL
@@ -6039,7 +6040,7 @@ political_decisions = {
 		}
 	}
 
-#from England.txt	
+#from England.txt
 	renew_alliance_british_india = {
 		potential = {
 			ai = yes
@@ -6062,11 +6063,11 @@ political_decisions = {
 				NOT = { alliance_with = THIS }
 			}
 		}
-		
+
 		allow = {
 			NOT = { month = 1 }
 		}
-		
+
 		effect = {
 			any_country = {
 				limit = {
@@ -6085,11 +6086,11 @@ political_decisions = {
 			# tag = ENG
 			# always = no
 		# }
-		
+
 		# allow = {
 			# tag = ENG
 		# }
-		
+
 		# effect = {
 			# any_pop = {
 				# limit = {
@@ -6138,13 +6139,13 @@ political_decisions = {
 			# NOT = { exists = EIC }
 			# NOT = { has_country_flag = end_mughals }
 		# }
-		
+
 		# allow = {
 			# war = no
 			# MUG = { ai = yes }
 			# NOT = { truce_with = MUG }
 		# }
-		
+
 		# effect = {
 			# diplomatic_influence = {
 				# who = MUG
@@ -6155,13 +6156,13 @@ political_decisions = {
 				# attacker_goal = { casus_belli = conquest_any }
 				# defender_goal = { casus_belli = status_quo }
 			# }
-			# set_country_flag = end_mughals 
+			# set_country_flag = end_mughals
 		# }
-		
+
 		# ai_will_do = { factor = 1 }
 	# }
 
-#from FlavourMod_SIA.txt		
+#from FlavourMod_SIA.txt
 	bowring_treaty = {
 		picture = john_bowring
 		potential = {
@@ -6175,24 +6176,24 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = bowring_treaty }
 		}
-		
+
 		allow = {
 			nationalism_n_imperialism = 1
-			SIA = { 
+			SIA = {
 				civilized = no
 				war = no
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = bowring_treaty
 			prestige = 5
 			SIA = { country_event = 99300 }
-		}	
-		
+		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from Setup.txt
 
 	literacy_ENG = {
@@ -6200,13 +6201,13 @@ political_decisions = {
 			tag = ENG
 			always = no
 		}
-		
+
 		allow = {
 			tag = ENG
 		}
-		
+
 		effect = {
-		
+
 			any_pop = {
 				limit = {
 					OR = {
@@ -6232,14 +6233,14 @@ political_decisions = {
 				}
 				literacy = -0.09
 			}
-			
+
 			any_pop = { limit = { has_pop_culture = central_american } literacy = 0.09 }
-			
+
 			any_pop = {
 				limit = { has_pop_religion = animist }
 				literacy = -0.09
 			}
-			
+
 			any_pop = {
 				limit = {
 					is_primary_culture = yes
@@ -6251,17 +6252,17 @@ political_decisions = {
 				limit = { has_pop_culture = yankee }
 				literacy = 0.70
 			}
-			
+
 			any_pop = {
 				limit = { has_pop_culture = australian }
 				literacy = -0.20
 			}
-			
+
 			any_pop = {
 				limit = { has_pop_culture = maltese }
 				literacy = 0.20
 			}
-			
+
 			any_pop = {
 				limit = { OR = { has_pop_culture = french_canadian has_pop_culture = metis has_pop_culture = french } }
 				literacy = 0.35
@@ -6270,29 +6271,29 @@ political_decisions = {
 				limit = { has_pop_culture = boer }
 				literacy = 0.15
 			}
-			
+
 			any_pop = {
 				limit = { has_pop_culture = north_german }
 				literacy = 0.6
 			}
-			
+
 			any_pop = {
 				limit = { has_pop_culture = french }
 				literacy = 0.4
 			}
-			
+
 			any_pop = {
 				limit = { has_pop_culture = north_italian }
 				literacy = 0.3
 			}
-			
+
 			any_pop = {
 				limit = { OR = { has_pop_culture = ashkenazi has_pop_culture = sephardic } }
 				literacy = 0.4
 			}
-			
+
 			SCO = { all_core = { any_pop = { limit = { NOT = { has_pop_culture = irish } } literacy = 0.2 } } }
-			
+
 			ENG_260 = { any_pop = { limit = { has_pop_culture = irish } literacy = 0.14 } }
 			ENG_258 = { any_pop = { limit = { has_pop_culture = irish } literacy = 0.05 } }
 			ENG_254 = { any_pop = { limit = { has_pop_culture = irish } literacy = 0.2 } }
@@ -6303,7 +6304,7 @@ political_decisions = {
 			any_pop = { limit = { has_pop_culture = irish location = { NOT = { is_core = IRE } is_colonial = no } } literacy = 0.2 }
 			any_pop = { limit = { has_pop_culture = north_italian } literacy = 0.25 }
 			any_pop = { limit = { has_pop_culture = spanish } literacy = 0.03 }
-			
+
 			any_pop = {
 				limit = {
 					OR = {
@@ -6316,7 +6317,7 @@ political_decisions = {
 				}
 				literacy = -0.99
 			}
-			
+
 			any_pop = {
 				limit = {
 					has_pop_culture = irish
@@ -6341,14 +6342,14 @@ political_decisions = {
 				}
 			}
 			2482 = { add_province_modifier = { name = penal_colony duration = -1 } }
-			
+
 			random_owned = {
 				limit = { owner = { ai = yes } }
 				AST = { set_country_flag = unreleasable_country }
 				NZL = { set_country_flag = unreleasable_country }
 			}
 		}
-	}	
+	}
   vassalize_trucial_states = {
     picture = dubai_city
     potential = {
@@ -6476,15 +6477,15 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = claimed_north_cape_colony }
 		}
-		
+
 		allow = {
 			owns = 2087
 			2093 = { NOT = { is_core = THIS } }
 		}
-		
+
 		effect = {
 			set_country_flag = claimed_north_cape_colony
-			2088 = { owner = { 
+			2088 = { owner = {
 			add_casus_belli = {
 				target = THIS
 				type = place_in_the_sun
@@ -6492,7 +6493,7 @@ political_decisions = {
 					}
 				}
 			}
-			2092 = { owner = { 
+			2092 = { owner = {
 			add_casus_belli = {
 				target = THIS
 				type = place_in_the_sun
@@ -6500,7 +6501,7 @@ political_decisions = {
 					}
 				}
 			}
-			2093 = { owner = { 
+			2093 = { owner = {
 			add_casus_belli = {
 				target = THIS
 				type = place_in_the_sun
@@ -6508,7 +6509,7 @@ political_decisions = {
 					}
 				}
 			}
-			2558 = { owner = { 
+			2558 = { owner = {
 			add_casus_belli = {
 				target = THIS
 				type = place_in_the_sun
@@ -6523,7 +6524,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	claim_xhosa_lands = {
 		picture = map_africa
 		potential = {
@@ -6536,14 +6537,14 @@ political_decisions = {
 			XHO = { exists = yes neighbour = THIS }
 			NOT = { has_country_flag = claimed_xhosa }
 		}
-		
+
 		allow = {
 			2100 = { NOT = { is_core = THIS } }
 			NOT = { truce_with = XHO }
 			NOT = { casus_belli = XHO }
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_country_flag = claimed_xhosa
 			badboy = 2
@@ -6555,7 +6556,7 @@ political_decisions = {
 			relation = { who = XHO value = -200 }
 			XHO = { leave_alliance = THIS }
 			release_vassal = XHO
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6567,7 +6568,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = demand_concession_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6579,7 +6580,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = establish_protectorate_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6591,7 +6592,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = demand_concession_NI_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6603,7 +6604,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = establish_protectorate_NI_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6615,7 +6616,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = demand_concession_BC_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6627,7 +6628,7 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = establish_protectorate_BC_casus_belli months = 40 }
 			}
-			
+
 			random_country = {
 			limit = {
 				tag = XHO
@@ -6637,9 +6638,9 @@ political_decisions = {
 				}
 			add_casus_belli = { target = THIS type = conquest_any months = 40 }
 			}
-			
+
 		}
 	}
-	
+
 
 }

--- a/TGC/decisions/France.txt
+++ b/TGC/decisions/France.txt
@@ -19,15 +19,15 @@ political_decisions = {
 					government = hms_government
 					government = democracy
 				}
-			}	
+			}
 			year = 1850
 		}
-	
+
 		allow = {
 			regenerative_furnaces = 1
 			USA = { slavery = no_slavery }
 		}
-	
+
 		effect = {
 			set_global_flag = statue_of_liberty_has_been_built
 			any_pop = {
@@ -47,7 +47,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	support_french_foreign_legion = {
 		potential = {
 			primary_culture = french
@@ -66,10 +66,10 @@ political_decisions = {
 			}
 			1700 = { fort = 2 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	french_military_mission_to_japan = {
 		picture = french_military_exp_japan
 		potential = {
@@ -88,7 +88,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = military_mission_in_japan }
 		}
-		
+
 		allow = {
 			state_n_government = 1
 			NOT = { war_with = JAP }
@@ -96,12 +96,12 @@ political_decisions = {
 			NOT = { war_with = TKG }
 			NOT = { truce_with = TKG }
 		}
-		
+
 		effect = {
 			prestige = 20
 			any_country = {
 				limit = {
-					OR = { 
+					OR = {
 						tag = TKG
 						tag = CHO
 						tag = JAP
@@ -118,10 +118,10 @@ political_decisions = {
 			FRA = { set_country_flag = military_mission_in_japan }
 			BOR = { set_country_flag = military_mission_in_japan }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	palais_garnier = {
 		potential = {
 			NOT = { has_country_flag = palais_garnier_built }
@@ -129,17 +129,17 @@ political_decisions = {
 			is_greater_power = yes
 			capital = 425
 		}
-		
+
 		allow = {
 			expressionism = 1
 		}
-		
+
 		effect = {
 			prestige = 10
 			FRA = { set_country_flag = palais_garnier_built }
 			BOR = { set_country_flag = palais_garnier_built }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -158,13 +158,13 @@ political_decisions = {
 				has_country_flag = crisis_on_the_rhine
 			}
 		}
-		
+
 		allow = {
 			war = no
 			NOT = { truce_with = PRU }
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			badboy = 2
 			add_country_modifier = {
@@ -187,7 +187,7 @@ political_decisions = {
 			FRA = { set_country_flag = crisis_on_the_rhine }
 			BOR = { set_country_flag = crisis_on_the_rhine }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -204,7 +204,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	build_the_eiffel_tower = {
 		picture = build_the_eiffel_tower
 		potential = {
@@ -214,13 +214,13 @@ political_decisions = {
 			NOT = {
 				has_country_flag = the_eiffel_tower_was_built
 			}
-			
+
 			OR = {
 				has_country_flag = world_fair_planner
 				year = 1887
 			}
 		}
-		
+
 		allow = {
 			war = no
 			regenerative_furnaces = 1
@@ -229,16 +229,16 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		effect = {
 			country_event = 37236
 			FRA = { set_country_flag = the_eiffel_tower_was_built }
 			BOR = { set_country_flag = the_eiffel_tower_was_built }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	haussmanns_renovations = {
 		picture = haussmanns_renovations
 		potential = {
@@ -252,7 +252,7 @@ political_decisions = {
 			}
 			year = 1852
 		}
-		
+
 		allow = {
 			iron_railroad = 1
 			business_banks = 1
@@ -261,7 +261,7 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		effect = {
 			random_owned = { limit = { owner = { ai = no } } owner = { treasury = -50000 } }
 			random_owned = {
@@ -277,10 +277,10 @@ political_decisions = {
 			FRA = { set_country_flag = extreme_home_makeover }
 			BOR = { set_country_flag = extreme_home_makeover }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	annex_mayotte = {
 		picture = dreams_of_empire
 		potential = {
@@ -289,12 +289,12 @@ political_decisions = {
 			capital = 425
 			2124 = { empty = yes }
 		}
-		
+
 		allow = {
 			war = no
 			medicine = 1
 		}
-		
+
 		effect = {
 			prestige = 3
 			2124 = { add_core = THIS }
@@ -306,17 +306,17 @@ political_decisions = {
 				change_province_name = "Mayotte"
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	claim_savoy = {
 		picture = form_italy
 		potential = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
-			OR = { 
+			OR = {
 				has_global_flag = plombieres
 				revolution_n_counterrevolution = 1
 			}
@@ -326,7 +326,7 @@ political_decisions = {
 				has_country_flag = claimed_savoy
 			}
 		}
-		
+
 		allow = {
 			OR = {
 				war_policy = jingoism
@@ -347,7 +347,7 @@ political_decisions = {
 				has_country_modifier = no_more_war
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claimed_savoy }
 			BOR = { set_country_flag = claimed_savoy }
@@ -370,14 +370,14 @@ political_decisions = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
-			OR = { 
+			OR = {
 				owns = 412 #Metz
 				owns = 720 #Turin
 			}
 			owns = 472 #Nice
 			NOT = { 721 = { is_core = THIS } }
 		}
-		
+
 		allow = {
 			OR = {
 				war_policy = jingoism
@@ -398,7 +398,7 @@ political_decisions = {
 				has_country_modifier = no_more_war
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claimed_aosta }
 			BOR = { set_country_flag = claimed_aosta }
@@ -410,7 +410,7 @@ political_decisions = {
 				relation = { who = THIS value = -100 }
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -420,7 +420,7 @@ political_decisions = {
 					466 = { NOT = { is_core = ITS } }
 				}
 			}
-			
+
 			modifier = {
 				factor = 0
 				badboy = 0.8
@@ -442,12 +442,12 @@ political_decisions = {
 				government = absolute_monarchy
 			}
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			prestige = 3
 			1097 = { add_core = THIS }
@@ -455,7 +455,7 @@ political_decisions = {
 			add_country_modifier = { name = penal_colonies duration = -1 }
 		}
 	}
-	
+
 	french_language_schooling = {
 		picture = embrace_minority
 		potential = {
@@ -466,14 +466,14 @@ political_decisions = {
 			BRT = { exists = no }
 			NOT = { has_country_flag = enacted_french_schooling	 }
 		}
-		
+
 		allow = {
 			war = no
 			NOT = { school_reforms = no_schools }
 			invention = biased_multiculturalism
 			invention = social_darwinism
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = enacted_french_schooling }
 			BOR = { set_country_flag = enacted_french_schooling }
@@ -546,10 +546,10 @@ political_decisions = {
 					vassal_of = THIS
 				}
 				primary_culture = french
-			}	
+			}
 		}
 	}
-	
+
 	st_barths_question = {
 		picture = map_caribbean
 		potential = {
@@ -564,7 +564,7 @@ political_decisions = {
 				owns = 2228
 			}
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
@@ -572,7 +572,7 @@ political_decisions = {
 			3246 = { owner = { NOT = { truce_with = THIS } relation = { who = THIS value = 60 } } }
 			money = 55000
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = st_barths_referendum }
 			BOR = { set_country_flag = st_barths_referendum }
@@ -588,22 +588,22 @@ political_decisions = {
 			NOT = { 409 = { trade_goods = precious_metal } }
 			regenerative_furnaces = 1
 		}
-		
+
 		allow = {
 			war = no
 			advanced_metallurgy = 1
 			money = 30100
 		}
-		
+
 		effect = {
 			money = -30000
 			412 = { trade_goods = iron }
 			409 = { trade_goods = precious_metal }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	french_iron_mines = {
 		picture = normandie_mine
 		potential = {
@@ -611,13 +611,13 @@ political_decisions = {
 			regenerative_furnaces = 1
 			NOT = { has_country_flag = french_mines_placed }
 		}
-		
+
 		allow = {
 			war = no
 			advanced_metallurgy = 1
 			money = 30100
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = french_mines_placed }
 			BOR = { set_country_flag = french_mines_placed }
@@ -627,10 +627,10 @@ political_decisions = {
 			428 = { trade_goods = iron }
 			411 = { trade_goods = iron }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #The Devil's Island
 devil_island = {
 	picture = FRA_devils_island
@@ -648,7 +648,7 @@ devil_island = {
 	allow = {
 		money = 5000
 	}
-		
+
 	effect = {
 		FRA = { set_country_flag = devil_island }
 		BOR = { set_country_flag = devil_island }
@@ -683,9 +683,9 @@ devil_island = {
 				}
 			}
 		}
-		
+
 		allow = {
-			OR = { 
+			OR = {
 				nationalism_n_imperialism = 1
 				AND = {
 					year = 1853
@@ -701,7 +701,7 @@ devil_island = {
 			}
 			NOT = { war_exhaustion = 1 }
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claimed_authority_over_holy_land }
 			BOR = { set_country_flag = claimed_authority_over_holy_land }
@@ -723,26 +723,26 @@ devil_island = {
 				}
 			}
 		}
-		
-		ai_will_do = { 
-			factor = 1 
+
+		ai_will_do = {
+			factor = 1
 			modifier = {
 				factor = 0
 				ENG = { war_with = USA }
 			}
-			
+
 			modifier = {
 				factor = 0
 				ENG = { war_with = TPG }
 			}
-			
+
 			modifier = {
 				factor = 0
 				ENG = { war_with = QNG }
 			}
 		}
 	}
-	
+
 	treaty_of_paris_1856 = {
 		picture = treaty_signing
 		potential = {
@@ -755,14 +755,14 @@ devil_island = {
 			NOT = { has_global_flag = berlin_congress_held }
 			NOT = { has_country_flag = crimean_surrender }
 		}
-		
+
 		allow = {
 			RUS = {
 				NOT = { war_with = TUR }
 				has_recently_lost_war = yes
 			}
 		}
-		
+
 		effect = {
 			prestige = 20
 			set_global_flag = treaty_of_paris_1856
@@ -859,12 +859,12 @@ devil_island = {
 			}
 			967 = { naval_base = -2 fort = -1 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 #from East Indies.txt
 create_cambodian_protectorate = {
 		picture = unequal_treaty
@@ -881,7 +881,7 @@ create_cambodian_protectorate = {
 			}
 			NOT = { has_global_flag = created_cambodian_protectorate }
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
@@ -897,7 +897,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = created_cambodian_protectorate
 			prestige = 10
@@ -961,12 +961,12 @@ create_cambodian_protectorate = {
 			}
 			has_global_flag = berlin_conference
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		effect = {
 			prestige = 5
 			any_neighbor_country = {
@@ -991,7 +991,7 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-	
+
 	siamese_border_treaty = {
 		picture = unequal_treaty
 		potential = {
@@ -1013,19 +1013,19 @@ create_cambodian_protectorate = {
 			owns = 1369
 			NOT = { has_country_flag = enacted_siamese_border_treaty }
 		}
-		
+
 		allow = {
 			NOT = { war_with = SIA }
 			SIA = { war = no }
 			invention = the_dark_continent
 		}
-		
+
 		effect = {
 			set_country_flag = enacted_siamese_border_treaty
 			SIA = { country_event = 95652 }
 		}
 	}
-	
+
 	annex_champasak = {
 		picture = unequal_treaty
 		potential = {
@@ -1044,12 +1044,12 @@ create_cambodian_protectorate = {
 			}
 			NOT = { has_country_flag = champassak_annexed }
 		}
-		
+
 		allow = {
 			war = no
 			has_recently_lost_war = no
 		}
-		
+
 		effect = {
 			set_country_flag = champassak_annexed
 			SIA = { release = CHK }
@@ -1077,7 +1077,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war_with = DAI
 			DAI = {
@@ -1092,7 +1092,7 @@ create_cambodian_protectorate = {
 				war_exhaustion = 10
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = negotiate_unequal_treaty
 			DAI = {
@@ -1100,12 +1100,12 @@ create_cambodian_protectorate = {
 				country_event = 95655
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 	organize_laos = {
 		picture = unequal_treaty
 		potential = {
@@ -1123,7 +1123,7 @@ create_cambodian_protectorate = {
 			}
 			owns = 1356
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
@@ -1131,7 +1131,7 @@ create_cambodian_protectorate = {
 			owns = 1357
 			owns = 1362
 		}
-		
+
 		effect = {
 			set_global_flag = laos_organized
 			prestige = 5
@@ -1170,7 +1170,7 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	form_french_indochina = {
 		picture = map_east_indies
 		potential = {
@@ -1186,12 +1186,12 @@ create_cambodian_protectorate = {
 			DAI = { exists = no }
 			NOT = { has_country_flag = created_french_indochina }
 		}
-		
+
 		allow = {
 			owns = 1380
 			revolution_n_counterrevolution = 1
 		}
-		
+
 		effect = {
 			set_country_flag = created_french_indochina
 			prestige = 10
@@ -1222,10 +1222,10 @@ create_cambodian_protectorate = {
 			}
 			DAI = { government = colonial_company }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from MiniMod-General.txt
 	form_laos = {
 		picture = unequal_treaty
@@ -1237,14 +1237,14 @@ create_cambodian_protectorate = {
 			}
 			NOT = { exists = LXA }
 		}
-		
+
 		allow = {
 			owns = 1357
 			owns = 1362
 			owns = 1361
 			owns = 1356
 		}
-		
+
 		effect = {
 			prestige = 20
 			change_tag = LXA
@@ -1271,7 +1271,7 @@ create_cambodian_protectorate = {
 			2572 = { add_core = LXA }
 			capital = 1357
 		}
-	}		
+	}
 #from MiniMod-Viet
 	annexation_of_cambodia = {
 		picture = force_vassal_freedom
@@ -1283,28 +1283,28 @@ create_cambodian_protectorate = {
 			NOT = { has_country_flag = annexation_of_cambodia }
 			civilized = yes
 		}
-		
+
 		allow = {
-			invention = national_fraternity	
+			invention = national_fraternity
 			prestige = 50
 			all_core = {
 				owned_by = THIS
 			}
 		}
-		
+
 		effect = {
 			badboy = 4
 			prestige = 10
-			set_country_flag = annexation_of_cambodia 
+			set_country_flag = annexation_of_cambodia
 			SIA_1366 = {
 				add_core = DAI
 			}
 			inherit = CAM
-		}	
-		
+		}
+
 	}
-	
-	
+
+
 	introduce_coffee_in_vietnam = {
 		picture = vietnam_coffee
 		potential = {
@@ -1329,7 +1329,7 @@ create_cambodian_protectorate = {
 			}
 			NOT = { has_country_flag = cashcrops_in_the_colonies }
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -1337,7 +1337,7 @@ create_cambodian_protectorate = {
 				steam_turbine = 1
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = cashcrops_in_the_colonies
 			random_owned = { limit = { province_id = 1380 NOT = { trade_goods = coffee } } trade_goods = coffee }
@@ -1362,10 +1362,10 @@ create_cambodian_protectorate = {
 			owns = 1784
 			year = 1845
 			NOT = { has_country_flag = faidherbe_ambitions }
-			WOL = { exists = yes ai = yes owns = 2573 } 
+			WOL = { exists = yes ai = yes owns = 2573 }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			colonial_nation = yes
@@ -1376,7 +1376,7 @@ create_cambodian_protectorate = {
 			NOT = { war_exhaustion = 5 }
 			slavery = no_slavery
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = faidherbe_ambitions }
 			BOR = { set_country_flag = faidherbe_ambitions }
@@ -1423,31 +1423,31 @@ create_cambodian_protectorate = {
 					is_vassal = no
 					vassal_of = THIS
 				}
-				OR = { 
+				OR = {
 					part_of_sphere = no
 					in_sphere = THIS
 				}
 			}
-			NOT = { has_country_flag = brazzas_expedition } 
+			NOT = { has_country_flag = brazzas_expedition }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			invention = colonial_negotiations
 			nationalism_n_imperialism = 1
 			total_amount_of_ships = 45
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = brazzas_expedition }
 			BOR = { set_country_flag = brazzas_expedition }
 			prestige = 5
 			inherit = LOA
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	ai_french_west_africa = {
 		picture = voulet_chanoine
 		potential = {
@@ -1455,10 +1455,10 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			capital = 425
 			has_global_flag = berlin_conference
-			NOT = { has_global_flag = ai_french_west_africa } 
+			NOT = { has_global_flag = ai_french_west_africa }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			is_disarmed = no
 			owns = 1894
@@ -1480,7 +1480,7 @@ create_cambodian_protectorate = {
 			}
 			total_amount_of_ships = 45
 		}
-		
+
 		effect = {
 			set_global_flag = ai_french_west_africa
 			any_country = {
@@ -1525,7 +1525,7 @@ create_cambodian_protectorate = {
 				country_event = 99959
 			}
 			random_owned = {
-				limit = { 
+				limit = {
 					port = yes
 					is_overseas = no
 					is_colonial = no
@@ -1546,10 +1546,10 @@ create_cambodian_protectorate = {
 				owner = { badboy = -15 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	###Occupation of the Congo###
 	occupation_of_the_congo = {
 		picture = the_congo_conference
@@ -1571,14 +1571,14 @@ create_cambodian_protectorate = {
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
 					1962 = { empty = no } #Cameroon
-				}	
+				}
 				AND = {
 					owns = 1967
 					1819 = { empty = yes } #Waddai
 				}
 			}
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			NOT = { has_global_flag = congo_failed }
@@ -1589,18 +1589,18 @@ create_cambodian_protectorate = {
 					1976 = { empty = yes } #Gabon
 				}
 				AND = {
-					OR = { 
+					OR = {
 						has_global_flag = called_congo_conference
 						1962 = { empty = no }
 					}
-					owns = 1977 
+					owns = 1977
 					1976 = { empty = no } #Gabon
 					1980 = { empty = yes } #Congo
 				}
 				AND = {
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
-				}	
+				}
 				AND = {
 					invention = the_dark_continent
 					owns = 1967
@@ -1608,7 +1608,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			###GABON##
 			random_owned = {
@@ -1627,11 +1627,11 @@ create_cambodian_protectorate = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1977	
+						owns = 1977
 						1976 = { empty = no } #Gabon
 						1980 = { empty = yes } #Congo
 						invention = colonial_negotiations
-						OR = { 
+						OR = {
 							has_global_flag = called_congo_conference
 							1962 = { empty = no }
 						}
@@ -1645,7 +1645,7 @@ create_cambodian_protectorate = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1981	
+						owns = 1981
 						1966 = { empty = yes } #Ubangi-Shari
 						1962 = { empty = no } #Cameroon
 						invention = the_dark_continent
@@ -1664,7 +1664,7 @@ create_cambodian_protectorate = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1967	
+						owns = 1967
 						1819 = { empty = yes }
 						invention = the_dark_continent
 					}
@@ -1679,14 +1679,14 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	senegal_gambia_border_treaty = {
 		picture = map_africa
 		potential = {
 			is_greater_power = yes
 			NOT = { owns = 1877 }
 			NOT = { owns = 1792 }
-			OR = { 
+			OR = {
 				owns = 1793
 				owns = 1878
 			}
@@ -1694,19 +1694,19 @@ create_cambodian_protectorate = {
 			1877 = { owner = { civilized = yes } }
 			has_global_flag = berlin_conference
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			set_country_flag = senegal_gambia_exchange
 			1877 = { owner = { country_event = 955181 } }
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	conquer_conakry = {
 		picture = louis_edouard
 		potential = {
@@ -1715,10 +1715,10 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			NOT = { owns = 1879 }
 			1879 = { owner = { civilized = no ai = yes } }
-			has_country_flag = faidherbe_ambitions 
+			has_country_flag = faidherbe_ambitions
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			war = no
 			is_disarmed = no
@@ -1734,7 +1734,7 @@ create_cambodian_protectorate = {
 			1879 = { owner = { OR = { part_of_sphere = no in_sphere = THIS } } }
 			total_amount_of_ships = 45
 		}
-		
+
 		effect = {
 			badboy = 1.5
 			random_country = {
@@ -1757,7 +1757,7 @@ create_cambodian_protectorate = {
 					months = 24
 					}
 				}
-				
+
 				random_country = {
 					limit = {
 						owns = 1879
@@ -1789,10 +1789,10 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-	
+
 	appoint_louis_briere = {
 		picture = "louis_briere"
-		potential = { 
+		potential = {
 			primary_culture = french
 			is_greater_power = yes
 			NOT = { government = proletarian_dictatorship }
@@ -1802,10 +1802,10 @@ create_cambodian_protectorate = {
 			year = 1865
 			FRA_1783 = { owned_by = THIS }
 			1791 = { owner = { OR = { civilized = no tag = THIS } } }
-			1795 = { owner = { OR = { civilized = no tag = THIS } } } 
+			1795 = { owner = { OR = { civilized = no tag = THIS } } }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			colonial_nation = yes
@@ -1818,7 +1818,7 @@ create_cambodian_protectorate = {
 			total_amount_of_ships = 45
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			prestige = 5
 			badboy = 5
@@ -1864,8 +1864,8 @@ create_cambodian_protectorate = {
 			}
 			set_country_flag = appoint_louis_briere
 		}
-		
-		ai_will_do = { 
+
+		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
@@ -1873,7 +1873,7 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-	
+
 	cotonou_concession = {
 		picture = dreams_of_empire
 		potential = {
@@ -1881,10 +1881,10 @@ create_cambodian_protectorate = {
 			capital_scope = { continent = europe }
 			is_greater_power = yes
 			1919 = { owner = { civilized = no ai = yes } }
-			nationalism_n_imperialism = 1 
+			nationalism_n_imperialism = 1
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			colonial_nation = yes
@@ -1898,7 +1898,7 @@ create_cambodian_protectorate = {
 			1919 = { owner = { civilized = no OR = { part_of_sphere = no in_sphere = THIS } } }
 			total_amount_of_ships = 45
 		}
-		
+
 		effect = {
 			badboy = 0.5
 			money = -45000
@@ -1906,7 +1906,7 @@ create_cambodian_protectorate = {
 			1919 = { owner = { relation = { who = THIS value = 100 } treasury = 45000 } }
 			1919 = { secede_province = THIS }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -1915,7 +1915,7 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-	
+
 	ivory_coast_conquest = {
 		picture = dreams_of_empire
 		potential = {
@@ -1930,7 +1930,7 @@ create_cambodian_protectorate = {
 			has_global_flag = berlin_conference
 			NOT = { invention = the_dark_continent }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			colonial_nation = yes
@@ -1939,7 +1939,7 @@ create_cambodian_protectorate = {
 			NOT = { war_policy = pacifism }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			1892 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 25 }
 			1893 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 25 }
@@ -1980,7 +1980,7 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	libreville_protectorate = {
 		picture = dreams_of_empire
 		potential = {
@@ -1990,26 +1990,26 @@ create_cambodian_protectorate = {
 			nationalism_n_imperialism = 1
 			capital_scope = { continent = europe }
 			any_owned_province = { has_building = naval_base }
-			OR = { 
-				any_owned_province = { continent = africa } 
-				any_owned_province = { continent = south_west_africa } 
-				any_owned_province = { continent = east_africa } 
+			OR = {
+				any_owned_province = { continent = africa }
+				any_owned_province = { continent = south_west_africa }
+				any_owned_province = { continent = east_africa }
 				any_owned_province = { continent = west_africa }
 				any_owned_province = { continent = central_africa }
 			}
 			owns = 1894
-			1972 = { empty = yes } 
+			1972 = { empty = yes }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			colonial_nation = yes
 			NOT = { any_greater_power = { war_with = THIS } }
-			OR = { 
-				any_owned_province = { continent = africa } 
-				any_owned_province = { continent = south_west_africa } 
-				any_owned_province = { continent = east_africa } 
+			OR = {
+				any_owned_province = { continent = africa }
+				any_owned_province = { continent = south_west_africa }
+				any_owned_province = { continent = east_africa }
 				any_owned_province = { continent = west_africa }
 				any_owned_province = { continent = central_africa }
 			}
@@ -2018,14 +2018,14 @@ create_cambodian_protectorate = {
 			NOT = { war_policy = pacifism }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			1972 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	###French North Africa###
 	organize_algeria_departments = {
 		picture = organize_french_algeria
@@ -2034,9 +2034,9 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			capital = 425
 			has_country_flag = 2nd_republic
-			NOT = { has_country_flag = organize_algeria_1848 } 
+			NOT = { has_country_flag = organize_algeria_1848 }
 		}
-		
+
 		allow = {
 			war = no
 			money = 55001
@@ -2045,7 +2045,7 @@ create_cambodian_protectorate = {
 			FRA_1700 = { owned_by = THIS }
 			NOT = { exists = ALD }
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = organize_algeria_1848 }
 			BOR = { set_country_flag = organize_algeria_1848 }
@@ -2054,17 +2054,17 @@ create_cambodian_protectorate = {
 			ALD_1708 = { add_core = THIS }
 			FRA_1700 = { add_core = THIS }
 			ALD = { government = colonial_company }
-			
+
 			any_pop = {
-				limit = { 
+				limit = {
 					culture = french
 					location = { is_core = ALD}
 				}
 				ideology = { factor = 0.9 value = conservative }
 			}
-			
+
 			any_pop = {
-				limit = { 
+				limit = {
 					culture = french
 					location = { is_core = ALD }
 					type = bureaucrats
@@ -2073,10 +2073,10 @@ create_cambodian_protectorate = {
 				reduce_pop = 1.5
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	cremieux_decree = {
 	picture = cremieux_decree
 		potential = {
@@ -2088,25 +2088,25 @@ create_cambodian_protectorate = {
 			ALD_1704 = { owned_by = THIS }
 			ALD_1708 = { owned_by = THIS }
 			FRA_1700 = { owned_by = THIS }
-			NOT = { has_country_flag = cremieux_decree } 
+			NOT = { has_country_flag = cremieux_decree }
 		}
-		
+
 		allow = {
 			war = no
 			ALD_1704 = { owned_by = THIS }
 			ALD_1708 = { owned_by = THIS }
 			FRA_1700 = { owned_by = THIS }
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = cremieux_decree }
 			BOR = { set_country_flag = cremieux_decree }
 			add_accepted_culture = sephardic
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	integrating_french_algeria = {
 		picture = french_algeria
 		potential = {
@@ -2123,7 +2123,7 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			OR = {
 				ruling_party_ideology = reactionary
-				ruling_party_ideology = fascist			
+				ruling_party_ideology = fascist
 			}
 			colonial_policy = settlement
 		}
@@ -2177,22 +2177,22 @@ create_cambodian_protectorate = {
 					name = colonial_recruitment
 					duration = 3650
 				}
-			}		
+			}
 		}
-		
-		ai_will_do = { 
-			factor = 1 
+
+		ai_will_do = {
+			factor = 1
 			modifier = { factor = 0 badboy = 0.8 }
 		}
 	}
-	
+
 	tunisian_colony = {
 		picture = tunisia_map
 		potential = {
 			capital_scope = { continent = europe }
-			TUN = { exists = yes civilized = no neighbour = THIS } 
+			TUN = { exists = yes civilized = no neighbour = THIS }
 			is_greater_power = yes
-			OR = { 
+			OR = {
 				is_sphere_leader_of = TUN
 				is_our_vassal = TUN
 				TUN = { part_of_sphere = no }
@@ -2200,7 +2200,7 @@ create_cambodian_protectorate = {
 			has_global_flag = berlin_conference
 			NOT = { has_global_flag = tunisian_colony }
 		}
-		
+
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			nationalism_n_imperialism = 1
@@ -2208,7 +2208,7 @@ create_cambodian_protectorate = {
 			TUN = { OR = { NOT = { money = 3000 } ai = yes } }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			set_global_flag = tunisian_colony
 			badboy = 2
@@ -2217,7 +2217,7 @@ create_cambodian_protectorate = {
 			leave_alliance = TUN
 			end_military_access = TUN
 			TUN = { end_military_access = THIS tech_school = unciv_tech_school }
-			any_country = { 
+			any_country = {
 				limit = { is_our_vassal = TUN }
 				release_vassal = TUN
 				casus_belli = { target = THIS type = free_peoples months = 40 }
@@ -2225,13 +2225,13 @@ create_cambodian_protectorate = {
 			}
 			war = { target = TUN attacker_goal = { casus_belli = conquest_any } defender_goal = { casus_belli = status_quo } }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = { factor = 0 badboy = 0.95 }
 		}
 	}
-	
+
 	#Madagascar
 	the_lambert_charter = {
 		potential = {
@@ -2239,10 +2239,10 @@ create_cambodian_protectorate = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
-			exists = MAD 
+			exists = MAD
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			state_n_government = 1
@@ -2254,7 +2254,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			random_country = {
 				limit = {
@@ -2270,10 +2270,10 @@ create_cambodian_protectorate = {
 			FRA = { set_country_flag = lambert_has_been_chartered }
 			BOR = { set_country_flag = lambert_has_been_chartered }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	end_the_merina_monarchy = {
 		picture = end_the_merina_monarchy
 		potential = {
@@ -2288,31 +2288,31 @@ create_cambodian_protectorate = {
 				civilized = no
 			}
 		}
-		
+
 		allow = {
 			MAD = {
 				in_sphere = THIS
 				war = no
 			}
-			OR = { 
-				any_owned_province = { continent = africa } 
-				any_owned_province = { continent = south_west_africa } 
-				any_owned_province = { continent = east_africa } 
+			OR = {
+				any_owned_province = { continent = africa }
+				any_owned_province = { continent = south_west_africa }
+				any_owned_province = { continent = east_africa }
 				any_owned_province = { continent = west_africa }
 				any_owned_province = { continent = central_africa }
 			}
 			has_global_flag = berlin_conference
 			invention = mission_to_civilize
 		}
-		
+
 		effect = {
 			set_global_flag = merina_monarchy_is_over
 			MAD = { country_event = 95505 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from FlavourMod_FRA_Colonial
 	the_quebec_question = {
 		picture = vive_le_quebec
@@ -2320,8 +2320,8 @@ create_cambodian_protectorate = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
-			NOT = { 
-				exists = CAN 
+			NOT = {
+				exists = CAN
 				exists = QUE
 				exists = FCA
 				exists = ACA
@@ -2330,19 +2330,19 @@ create_cambodian_protectorate = {
 			has_country_flag = french_america
 			NOT = { has_country_flag = demanded_quebec }
 		}
-		
+
 		allow = {
 			war = no
 			NOT = { truce_with = ENG }
 			money = 200000
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = demanded_quebec }
 			BOR = { set_country_flag = demanded_quebec }
 			ENG = { country_event = 7790003 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -2366,8 +2366,8 @@ create_cambodian_protectorate = {
 					ENG = { war_exhaustion = 10 }
 					NOT = { national_provinces_occupied = 0.05 }
 					NOT = { war_exhaustion = 35 }
-				}	
-				AND = { 
+				}
+				AND = {
 					truce_with = ENG
 					is_greater_power = yes
 					ENG = {
@@ -2379,18 +2379,18 @@ create_cambodian_protectorate = {
 		}
 
 		effect = {
-			FRA = { 
-				set_country_flag = quebec_regained 
+			FRA = {
+				set_country_flag = quebec_regained
 				set_country_flag = quebec_and_acadia_only
 			}
-			BOR = { 
-				set_country_flag = quebec_regained 
+			BOR = {
+				set_country_flag = quebec_regained
 				set_country_flag = quebec_and_acadia_only
 			}
 			prestige = 10
 			badboy = 5
 			treasury = -100000
-			random_owned = { 
+			random_owned = {
 				limit = { owner = { war_with = ENG } }
 				owner = { end_war = ENG }
 				any_country = { limit = { war_with = THIS alliance_with = ENG } end_war = THIS }
@@ -2400,18 +2400,18 @@ create_cambodian_protectorate = {
 			76 = { add_core = QUE }
 			77 = { add_core = QUE }
 			CAN_60 = { add_core = QUE }
-			ENG = { 
-				any_owned = { limit = { OR = { is_core = QUE is_core = ACA } } secede_province = THIS } 
+			ENG = {
+				any_owned = { limit = { OR = { is_core = QUE is_core = ACA } } secede_province = THIS }
 				any_pop = { limit = { has_pop_culture = french_canadian } move_pop = 65 }
 			}
 			RPL = { any_owned = { limit = { OR = { is_core = QUE is_core = ACA } } secede_province = THIS } }
-			QUE = { 
+			QUE = {
 				all_core = {
-					remove_core = THIS 
-					remove_core = CAN 
+					remove_core = THIS
+					remove_core = CAN
 					remove_core = RPL
 					remove_core = NEW
-				} 
+				}
 			}
 			USA = { remove_accepted_culture = cajun }
 			remove_accepted_culture = cajun
@@ -2453,7 +2453,7 @@ create_cambodian_protectorate = {
 			2625 = { add_core = QUE	}
 			76 = { add_core = QUE }
 			ENG = {
-				any_owned = { 
+				any_owned = {
 					limit = { OR = { is_core = CAN is_core = MRU is_core = NEW is_core = QUE is_core = COL is_core = RPL } }
 					remove_core = ENG
 					secede_province = THIS
@@ -2465,7 +2465,7 @@ create_cambodian_protectorate = {
 
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	#Organize Acadia
 	organize_acadia = {
 		picture = "organize_acadia"
@@ -2475,28 +2475,28 @@ create_cambodian_protectorate = {
 			capital = 425
 			has_country_flag = quebec_regained
 			owns = 71
-			NOT = { 
-				exists = MRU 
+			NOT = {
+				exists = MRU
 				exists = ACA
 				exists = FCA
-				has_country_flag = acadia_organized 
+				has_country_flag = acadia_organized
 			}
 		}
-		
+
 		allow = {
 			money = 50000
 			war = no
 			ACA = { all_core = { owned_by = THIS } }
 		}
-		
+
 		effect = {
 			money = -50000
 			ACA = { set_country_flag = post_colonial_country }
-			any_pop = { 
-				limit = { 
-					location = { is_core = ACA } 
-					culture = french_canadian 
-				} 
+			any_pop = {
+				limit = {
+					location = { is_core = ACA }
+					culture = french_canadian
+				}
 				militancy = -10
 				consciousness = -10
 				reduce_pop = 2
@@ -2574,7 +2574,7 @@ create_cambodian_protectorate = {
 					has_pop_culture = yankee
 				}
 				move_pop = 243
-			}	
+			}
 			any_owned = {
 				limit = { is_core = ACA }
 				add_province_modifier = {
@@ -2582,7 +2582,7 @@ create_cambodian_protectorate = {
 					duration = 1825
 				}
 			}
-			random_owned = { limit = { owner = { has_country_flag = french_total_victory } } 
+			random_owned = { limit = { owner = { has_country_flag = french_total_victory } }
 				ACA = { all_core = { add_core = FCA remove_core = ACA } }
 			}
 			###Set Acadia Flag Based on whether Bourbon/Napoleonic###
@@ -2592,10 +2592,10 @@ create_cambodian_protectorate = {
 			FRA = { set_country_flag = acadia_organized }
 			BOR = { set_country_flag = acadia_organized }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	organize_canada = {
 		picture = "vive_le_quebec"
 		potential = {
@@ -2603,7 +2603,7 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			capital = 425
 			NOT = {
-				exists = QUE 
+				exists = QUE
 				exists = ACA
 				exists = ULA
 				exists = FCA
@@ -2611,7 +2611,7 @@ create_cambodian_protectorate = {
 			has_country_flag = quebec_regained
 			NOT = { has_country_flag = canada_organized }
 		}
-		
+
 		allow = {
 			money = 100001
 			war = no
@@ -2620,7 +2620,7 @@ create_cambodian_protectorate = {
 			owns = 2592
 			owns = 71
 		}
-		
+
 		effect = {
 			###Effects that will happen if either the Treaty of Montreal or Paris is taken###
 			treasury = -100000
@@ -2638,7 +2638,7 @@ create_cambodian_protectorate = {
 			any_pop = {
 				limit = {
 					OR = {
-						culture = anglo_canadian 
+						culture = anglo_canadian
 						culture = irish
 						culture = british
 					}
@@ -2647,7 +2647,7 @@ create_cambodian_protectorate = {
 				militancy = 7
 			}
 			any_pop = {
-				limit = { 
+				limit = {
 				has_pop_culture = british
 				location = { is_core = QUE } }
 				move_pop = 57
@@ -2663,13 +2663,13 @@ create_cambodian_protectorate = {
 			MRU = { all_core = { remove_core = MRU } }
 			###British Acadia###
 			any_pop = {
-				limit = { location = { province_id = 72 } culture = french_canadian } 
+				limit = { location = { province_id = 72 } culture = french_canadian }
 				reduce_pop = 1.5
 				militancy = -10
 				consciousness = -10
 			}
 			###End of Common Effects###
-			
+
 			###Effects for Treaty of Paris - This will end the French Goals in North America###
 			random_owned = {
 				limit = { owner = { has_country_flag = quebec_and_acadia_only } }
@@ -2685,12 +2685,12 @@ create_cambodian_protectorate = {
 							name = french_colonial_integration
 							duration = 1825
 						}
-					}	
+					}
 				}
 				FRA = { set_country_flag = no_more_north_america }
-				BOR = { set_country_flag = no_more_north_america }	
+				BOR = { set_country_flag = no_more_north_america }
 			}
-			
+
 			###Effects for Treaty of Montreal - Will change cores for the whole of British North America###
 			random_owned = {
 				limit = { owner = { has_country_flag = french_total_victory } }
@@ -2707,12 +2707,12 @@ create_cambodian_protectorate = {
 							name = french_colonial_integration
 							duration = 1825
 						}
-					}	
+					}
 				}
-				FCA = { 
+				FCA = {
 					remove_accepted_culture = french
 					add_accepted_culture = anglo_canadian
-					set_country_flag = post_colonial_country 
+					set_country_flag = post_colonial_country
 				}
 			}
 			###Set Canada Flag Based on whether Bourbon/Napoleonic###
@@ -2724,7 +2724,7 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	french_louisiana = {
 		picture = new_france_louisiana
 		potential = {
@@ -2734,20 +2734,20 @@ create_cambodian_protectorate = {
 			has_country_flag = french_total_victory
 			has_country_flag = french_america
 			has_country_flag = canada_organized
-			NOT = { 
-				has_country_flag = war_for_louisiana 
+			NOT = {
+				has_country_flag = war_for_louisiana
 				exists = ULA
 				exists = FCA
 			}
 		}
-		
+
 		allow = {
 			war = no
 			NOT = { truce_with = USA }
 			NOT = { war_policy = pacifism }
 			NOT = { revolution_n_counterrevolution = 1 }
 		}
-		
+
 		effect = {
 			badboy = 25
 			USA = {
@@ -2778,8 +2778,8 @@ create_cambodian_protectorate = {
 			any_pop = {
 				limit = {
 					OR = {
-						has_pop_culture = mexican 
-						has_pop_culture = yankee 
+						has_pop_culture = mexican
+						has_pop_culture = yankee
 						has_pop_culture = british
 						has_pop_culture = anglo_canadian
 					}
@@ -2799,7 +2799,7 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-	
+
 	treaty_of_new_york = {
 		picture = establish_panfrenchism
 		potential = {
@@ -2850,8 +2850,8 @@ create_cambodian_protectorate = {
 							province_id = 78
 							province_id = 79
 						}
-						NOT = { 
-							province_id = 129 
+						NOT = {
+							province_id = 129
 							province_id = 110
 							province_id = 107
 							province_id = 128
@@ -2879,7 +2879,7 @@ create_cambodian_protectorate = {
 			ULA = { all_core = { remove_core = FCA } }
 			THIS = {
 				any_owned = {
-					limit = { is_core = USA 
+					limit = { is_core = USA
 					NOT = { is_core = ACA is_core = ULA region = USA_78 } }
 					secede_province = USA
 					remove_core = THIS
@@ -2888,7 +2888,7 @@ create_cambodian_protectorate = {
 			}
 			###Turn all these states into colonies
 			any_owned = {
-				limit = { 
+				limit = {
 					OR = {
 						region = USA_118 #North Dakota
 						region = USA_121 #South Dakota
@@ -2921,12 +2921,12 @@ create_cambodian_protectorate = {
 				}
 			}
 			46 = { state_scope = { change_region_name = "Southern Ontario" } }
-			
+
 		}
 
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	organize_louisiana	= {
 		picture = "new_france_louisiana"
 		potential = {
@@ -2935,8 +2935,8 @@ create_cambodian_protectorate = {
 			capital = 425
 			has_country_flag = quebec_regained
 			has_global_flag = treaty_of_new_york
-			NOT = { 
-				has_country_flag = louisiana_organized 
+			NOT = {
+				has_country_flag = louisiana_organized
 				exists = ULA
 			}
 		}
@@ -2968,8 +2968,8 @@ create_cambodian_protectorate = {
 						province_id = 78
 						province_id = 79
 					}
-					NOT = { 
-						province_id = 129 
+					NOT = {
+						province_id = 129
 						province_id = 110
 						province_id = 107
 						province_id = 128
@@ -3001,8 +3001,8 @@ create_cambodian_protectorate = {
 							province_id = 78
 							province_id = 79
 						}
-						NOT = { 
-							province_id = 129 
+						NOT = {
+							province_id = 129
 							province_id = 110
 							province_id = 107
 							province_id = 128
@@ -3038,8 +3038,8 @@ create_cambodian_protectorate = {
 			}
 			ULA = {
 				set_country_flag = post_colonial_country
-				primary_culture = cajun 
-				add_accepted_culture = acadian 
+				primary_culture = cajun
+				add_accepted_culture = acadian
 			}
 			ULA = { all_core = { remove_core = COL remove_core = FCA } }
 			D01 = { primary_culture = cajun }
@@ -3172,8 +3172,8 @@ create_cambodian_protectorate = {
 				}
 			}
 			any_pop = {
-				limit = { 
-						has_pop_culture = cajun 
+				limit = {
+						has_pop_culture = cajun
 				}
 				reduce_pop = 3
 			}
@@ -3183,14 +3183,14 @@ create_cambodian_protectorate = {
 			random_owned = { limit = { owner = { NOT = { colonial_policy = settlement } } } owner = { political_reform = settlement } }
 			random_owned = { limit = { owner = { tag = FRA OR = { government = hms_government government = absolute_monarchy government = prussian_constitutionalism } } ULA = { government = hms_government } } }
 			random_owned = { limit = { owner = { tag = BOR } } ULA = { government = colonial_company } }
-			
+
 			FRA = { set_country_flag = louisiana_organized }
 			BOR = { set_country_flag = louisiana_organized }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	organize_algeria_fra = {
 		picture = "organize_french_algeria"
 		potential = {
@@ -3200,23 +3200,23 @@ create_cambodian_protectorate = {
 			NOT = {
 				exists = ALD
 				has_global_flag = algeria_organized
-				capital_scope = { continent = africa } 
-				capital_scope = { continent = west_africa } 
-				capital_scope = { continent = central_africa } 
-				capital_scope = { continent = east_africa } 
+				capital_scope = { continent = africa }
+				capital_scope = { continent = west_africa }
+				capital_scope = { continent = central_africa }
+				capital_scope = { continent = east_africa }
 				capital_scope = { continent = south_west_africa }
 			}
 			owns = 1700
 			owns = 1721
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
 			owns = 1700
 			owns = 1721
 		}
-		
+
 		effect = {
 			set_global_flag = algeria_organized
 			prestige = 3
@@ -3232,15 +3232,15 @@ create_cambodian_protectorate = {
 				primary_culture = french
 				add_accepted_culture = maghrebi
 			}
-			1700 = { 
-				change_province_name = "Alger" 
+			1700 = {
+				change_province_name = "Alger"
 				state_scope = { change_region_name = "Alger" }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #from FlavourMod_FRA.txt
 	notre_dame_afrique = {
 		picture = notre_dame_afrique
@@ -3256,7 +3256,7 @@ create_cambodian_protectorate = {
 			impressionism = 1
 			war = no
 		}
-		
+
 		effect = {
 			badboy = -1
 			prestige = 5
@@ -3266,7 +3266,7 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	claim_monaco = {
 	picture = establish_panfrenchism
 		potential = {
@@ -3291,28 +3291,28 @@ create_cambodian_protectorate = {
 				ai = yes
 			}
 		}
-		
+
 		allow = {
 			war_policy = jingoism
-			NOT = { 
+			NOT = {
 				OR = {
 					relation = { who = ITA value = 100 }
 					relation = { who = ITS value = 100 }
 				}
 			}
-			MNC = { 
-				OR = { 
-					NOT = { 
+			MNC = {
+				OR = {
+					NOT = {
 						OR = {
 							vassal_of = ITA
 							vassal_of = ITS
 						}
-					} 
-					vassal_of = THIS 
-				} 
+					}
+					vassal_of = THIS
+				}
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claim_monaco }
 			BOR = { set_country_flag = claim_monaco }
@@ -3335,7 +3335,7 @@ create_cambodian_protectorate = {
 			exists = DAI
 			exists = QNG
 		}
-		
+
 		allow = {
 			DAI = {
 				civilized = no
@@ -3343,19 +3343,19 @@ create_cambodian_protectorate = {
 			}
 			owns = 1380
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = tonkin_campaign }
 			BOR = { set_country_flag = tonkin_campaign }
 			country_event = {
 				id = 99949
 				days = 150
-			}			
+			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	claim_luxembourg = {
 	picture = luxembourg_crisis
 		potential = {
@@ -3375,7 +3375,7 @@ create_cambodian_protectorate = {
 			LUX = { vassal_of = NET }
 			NOT = { has_country_flag = claim_luxmebourg }
 		}
-		
+
 		allow = {
 			war = no
 			crisis_exist = no
@@ -3392,7 +3392,7 @@ create_cambodian_protectorate = {
 			NOT = { truce_with = NET }
 			NOT = { truce_with = LUX }
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claim_luxmebourg }
 			BOR = { set_country_flag = claim_luxmebourg }
@@ -3400,20 +3400,20 @@ create_cambodian_protectorate = {
 			any_country = {
 				limit = {
 					exists = yes
-					OR  = { 
-						AND = { 
+					OR  = {
+						AND = {
 							tag = PRU
 							549 = { OR = { owned_by = PRU owner = { in_sphere = PRU OR = { is_vassal = no vassal_of = PRU } } } }
 						}
-						AND = { 
+						AND = {
 							tag = NGF
 							549 = { OR = { owned_by = NGF owner = { in_sphere = NGF OR = { is_vassal = no vassal_of = NGF } } } }
 						}
-						AND = { 
+						AND = {
 							tag = GER
 							549 = { OR = { owned_by = GER owner = { in_sphere = GER OR = { is_vassal = no vassal_of = GER } } } }
 						}
-						AND = { 
+						AND = {
 							tag = GCF
 							549 = { OR = { owned_by = GCF owner = { in_sphere = GCF OR = { is_vassal = no vassal_of = GCF } } } }
 						}
@@ -3422,8 +3422,8 @@ create_cambodian_protectorate = {
 				country_event = 99979
 			}
 		}
-		ai_will_do = { 
-			factor = 1 
+		ai_will_do = {
+			factor = 1
 			modifier = { factor = 0 badboy = 0.85 }
 		}
 	}
@@ -3446,7 +3446,7 @@ create_cambodian_protectorate = {
 			WLL = { all_core = { NOT = { owned_by = THIS } } }
 			owns = 412
 		}
-		
+
 		allow = {
 			crisis_exist = no
 			war = no
@@ -3470,7 +3470,7 @@ create_cambodian_protectorate = {
 				AND = { owns = 575 owns = 573 }
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claim_wallonia }
 			BOR = { set_country_flag = claim_wallonia }
@@ -3486,7 +3486,7 @@ create_cambodian_protectorate = {
 				country_event = 99984
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -3494,8 +3494,8 @@ create_cambodian_protectorate = {
 				badboy = 0.6
 			}
 		}
-	}	
-	
+	}
+
 	establish_panfrenchism = {
 	picture = establish_panfrenchism
 		potential = {
@@ -3508,20 +3508,20 @@ create_cambodian_protectorate = {
 			NOT = { exists = GER }
 			NOT = { has_global_flag = pan_french_nationalism }
 		}
-		
+
 		allow = {
 			war_policy = jingoism
 			state_n_government = 1
 		}
-		
+
 		effect = {
 			set_global_flag = pan_french_nationalism
 			prestige = 20
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	integrate_guyana = {
 		picture = french_guyane
 		potential = {
@@ -3529,7 +3529,7 @@ create_cambodian_protectorate = {
 			is_greater_power = yes
 			capital = 425
 			owns = 2241
-			owns = 2246			
+			owns = 2246
 			year = 1880
 			NOT = { has_country_flag = french_guiana }
 		}
@@ -3548,10 +3548,10 @@ create_cambodian_protectorate = {
 			FRA = { set_country_flag = french_guiana }
 			BOR = { set_country_flag = french_guiana }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	haitian_integration = {
 		picture = map_caribbean
 		potential = {
@@ -3568,7 +3568,7 @@ create_cambodian_protectorate = {
 		}
 		allow = {
 			biologism = 1
-			NOT = { average_militancy = 3 }	
+			NOT = { average_militancy = 3 }
 		}
 		effect = {
 			any_pop = {
@@ -3606,13 +3606,13 @@ create_cambodian_protectorate = {
 			capital = 425
 			NOT = { has_country_flag = walloon_autonomy }
 		}
-		
+
 		allow = {
 			war = no
 			ruling_party_ideology = liberal
 			394 = {	average_militancy = 7 }
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = walloon_autonomy }
 			BOR = { set_country_flag = walloon_autonomy }
@@ -3643,7 +3643,7 @@ create_cambodian_protectorate = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	claim_catalonia = {
 		picture = french_catalonia
 		potential = {
@@ -3655,7 +3655,7 @@ create_cambodian_protectorate = {
 			NOT = { has_country_flag = siezing_catalonia }
 			has_global_flag = pan_french_nationalism
 		}
-		
+
 		allow = {
 			OR =  {
 				SPA = { exists = yes is_greater_power = no NOT = { relation = { who = THIS value = 100 } } }
@@ -3681,7 +3681,7 @@ create_cambodian_protectorate = {
 				has_country_modifier = no_more_war
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = siezing_catalonia }
 			BOR = { set_country_flag = siezing_catalonia }
@@ -3702,14 +3702,14 @@ create_cambodian_protectorate = {
 			modifier = { factor = 0 badboy = 0.5 }
 		}
 	}
-	
+
 	claim_andorra = {
 	picture = establish_panfrenchism
 		potential = {
 			primary_culture = french
 			is_greater_power = yes
 			capital = 425
-			OR = { 
+			OR = {
 				has_country_flag = siezing_catalonia
 				owns = 498
 			}
@@ -3718,7 +3718,7 @@ create_cambodian_protectorate = {
 			NOT = { has_country_flag = claim_andorra }
 			498 = { owned_by = THIS }
 		}
-		
+
 		allow = {
 			nationalism_n_imperialism = 1
 			OR = {
@@ -3735,7 +3735,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = claim_andorra }
 			BOR = { set_country_flag = claim_andorra }
@@ -3746,7 +3746,7 @@ create_cambodian_protectorate = {
 
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	clean_up_fra_vassal = {
 		picture = become_wallonia
 		potential = {
@@ -3754,23 +3754,23 @@ create_cambodian_protectorate = {
 			NOT = { tag = FRA tag = BOR }
 			NOT = { has_country_flag = french_bourbon_fixed }
 		}
-		
+
 		allow = {
 			exists = yes
 		}
-		
+
 		effect = {
 			set_country_flag = french_bourbon_fixed
 			government = hms_government
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	clean_up_fra_rhineland = {
 		picture = adolphe_thiers
 		potential = {
 			tag = RHI
-			RHI = { 
+			RHI = {
 				exists = yes
 				ai = yes
 				OR = { in_sphere = FRA in_sphere = BOR }
@@ -3778,16 +3778,16 @@ create_cambodian_protectorate = {
 			}
 			NOT = { has_country_flag = rhine_vassal }
 		}
-		
+
 		allow = {
 			war = no
-			OR = { 
+			OR = {
 				FRA = { truce_with = PRU has_country_modifier = rhine_crisis }
 				BOR = { truce_with = PRU has_country_modifier = rhine_crisis }
 			}
 			PRU = { has_recently_lost_war = yes }
 		}
-		
+
 		effect = {
 			set_country_flag = rhine_vassal
 			prestige = -50
@@ -3811,18 +3811,18 @@ create_cambodian_protectorate = {
 		potential = {
 			ai = yes
 			NOT = { has_global_flag = clean_up_france_lost_rhine_crisis }
-			OR = { 
+			OR = {
 				FRA = { truce_with = PRU has_country_modifier = rhine_crisis }
 				BOR = { truce_with = PRU has_country_modifier = rhine_crisis }
 			}
 			575 = { OR = {owned_by = PRU owned_by = NGF owned_by = GER owned_by = GCF owned_by = AUS owned_by = SGF } }
 			PRU = { is_disarmed = no }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			set_global_flag = clean_up_france_lost_rhine_crisis
 			random_country = {
@@ -3834,10 +3834,10 @@ create_cambodian_protectorate = {
 				country_event = 99993
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	take_the_channel_islands = {
 		picture = channel_islands
 		potential = {
@@ -3851,7 +3851,7 @@ create_cambodian_protectorate = {
 			capital = 425
 			419 = { NOT = { is_core = THIS } }
 		}
-		
+
 		allow = {
 			war = no
 			total_amount_of_ships = 20
@@ -3871,19 +3871,19 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			badboy = 1
 			419 = { secede_province = THIS }
 			419 = { add_core = THIS }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = { factor = 0 badboy = 0.8 }
 		}
 	}
-	
+
 	annex_rhineland = {
 	picture = rhineland
 		potential = {
@@ -3894,9 +3894,9 @@ create_cambodian_protectorate = {
 			has_recently_lost_war = no
 			NOT = { has_country_flag = annexed_rhineland }
 		}
-		
+
 		allow = {
-			war = no		
+			war = no
 			owns = 412
 			revolution_n_counterrevolution = 1
 			is_greater_power = yes
@@ -3908,7 +3908,7 @@ create_cambodian_protectorate = {
 				}
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = annexed_rhineland }
 			BOR = { set_country_flag = annexed_rhineland }
@@ -3916,13 +3916,13 @@ create_cambodian_protectorate = {
 			badboy = 8
 			inherit = RHI
 		}
-		
-		ai_will_do = { 
+
+		ai_will_do = {
 			factor = 1
 			modifier = { factor = 0 badboy = 0.5 }
 		}
 	}
-	
+
 	reclaim_alsace = {
 	picture = black_stain
 		alert = no
@@ -3939,7 +3939,7 @@ create_cambodian_protectorate = {
 			NOT = { has_country_flag = black_stain }
 			NOT = { has_global_flag = reclaim_elass_lorraine }
 		}
-		
+
 		allow = {
 			OR = {
 				AND = {
@@ -3974,7 +3974,7 @@ create_cambodian_protectorate = {
 				ai = no
 			}
 		}
-		
+
 		effect = {
 			FRA = { set_country_flag = black_stain }
 			BOR = { set_country_flag = black_stain }
@@ -3986,10 +3986,10 @@ create_cambodian_protectorate = {
 			}
 			set_global_flag = reclaim_elass_lorraine
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	the_treaty_of_milan = {
 	picture = establish_panfrenchism
 		potential = {
@@ -4012,11 +4012,11 @@ create_cambodian_protectorate = {
 			owns = 721 #Aosta
 			NOT = { has_global_flag = the_treaty_of_milan }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			set_global_flag = the_treaty_of_milan
 			prestige = 5
@@ -4038,9 +4038,9 @@ create_cambodian_protectorate = {
 				secede_province = ITS
 			}
 		}
-		
-		ai_will_do = { 
-			factor = 1 
+
+		ai_will_do = {
+			factor = 1
 			modifier = { factor = 0 badboy = 0.8 }
 		}
 	}
@@ -4055,17 +4055,18 @@ create_cambodian_protectorate = {
 			nationalism_n_imperialism = 1
 			2632 = { owner = { civilized = no NOT = { war_with = THIS }  } }
 			NOT = { has_country_flag = kwangchowan_treaty_port_fra }
+			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
-			OR = { 
+			OR = {
 				year = 1890
 				truce_with = QNG
 				truce_with = TPG
 			}
 			2632 = { owner = { civilized = no } }
 		}
-		
+
 		effect = {
 			set_country_flag = kwangchowan_treaty_port_fra
 			2632 = { secede_province = THIS change_controller = THIS }
@@ -4076,7 +4077,7 @@ create_cambodian_protectorate = {
 				set_variable = { which = china_destablization value = 1 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 #from FlavourMod_Qing.txt
@@ -4093,11 +4094,11 @@ create_cambodian_protectorate = {
 			NOT = { exists = DAI }
 			NOT = { has_global_flag = treaty_of_tientsin_france }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			set_global_flag = treaty_of_tientsin_france
 			prestige = 5
@@ -4113,20 +4114,20 @@ create_cambodian_protectorate = {
 				all_core = { remove_core = HQJ }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-#from Literacy.txt	
+#from Literacy.txt
 	literacy_FRA = {
 		potential = {
 			tag = FRA
 			always = no
 		}
-		
+
 		allow = {
 			tag = FRA
 		}
-		
+
 		effect = {
 			any_pop = {
 				limit = {
@@ -4157,7 +4158,7 @@ create_cambodian_protectorate = {
 			}
 		}
 	}
-#from MiniMod-FRA.txt	
+#from MiniMod-FRA.txt
 	revengance = {
 		picture = abolish_prohibition
 		potential = {
@@ -4197,7 +4198,7 @@ create_cambodian_protectorate = {
 				militancy = 10
 			}
 		}
-	
+
 		ai_will_do = {
 			factor = 0
 			modifier = {
@@ -4211,10 +4212,10 @@ create_cambodian_protectorate = {
 			modifier = {
 				factor = 1
 				government = absolute_monarchy
-			}			
-		}	
-		
-	} 	
+			}
+		}
+
+	}
 #from more decisions.txt
 	FRA_SRD_claim_rebuke = {
 		picture = italian_islands
@@ -4253,7 +4254,7 @@ create_cambodian_protectorate = {
 			factor = 1
 		}
 	}
-#from more decisions.txt	
+#from more decisions.txt
 	FRA_cancel_elasstreaty = {
 		picture = establish_panfrenchism
 		potential = {
@@ -4297,13 +4298,13 @@ create_cambodian_protectorate = {
 				}
 				country_event = 2317187
 			}
-			move_issue_percentage = { 
-				from = pro_military 
+			move_issue_percentage = {
+				from = pro_military
 				to = jingoism
 				value = 0.25
 			}
-			move_issue_percentage = { 
-				from = anti_military 
+			move_issue_percentage = {
+				from = anti_military
 				to = pro_military
 				value = 0.25
 			}
@@ -4312,23 +4313,23 @@ create_cambodian_protectorate = {
 			factor = 1
 		}
 	}
-#from Setup.txt	
+#from Setup.txt
 	france_1836_setup = {
 		picture = constantinople
 		potential = {
 			tag = FRA
 			always = no
 		}
-		
+
 		allow = {
 			tag = FRA
 		}
-		
+
 		effect = {
 			425 = { any_pop = { literacy = 0.05 } }
-			any_pop = { 
+			any_pop = {
 				limit = {
-					is_primary_culture = yes 
+					is_primary_culture = yes
 					has_pop_religion = protestant
 				}
 				literacy = 0.05
@@ -4419,6 +4420,6 @@ create_cambodian_protectorate = {
 			factor = 1
 		}
 	}
-	
+
 }
 

--- a/TGC/decisions/Germany.txt
+++ b/TGC/decisions/Germany.txt
@@ -20,7 +20,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -29,11 +29,11 @@ political_decisions = {
 				machine_guns = 1
 				AND = {
 					nationalism_n_imperialism = 1
-					has_country_modifier = prussian_general_staff 
+					has_country_modifier = prussian_general_staff
 					ai = no
 				}
 			}
-			OR = { 
+			OR = {
 				FRA = {
 					exists = yes
 					OR = { is_mobilised = no war = no }
@@ -58,14 +58,14 @@ political_decisions = {
 			}
 			crisis_exist = no
 		}
-		
+
 		effect = {
 			prestige = 5
 			random_country = {
 				limit = {
 					primary_culture = french
 					capital = 425
-				}	
+				}
 				country_event = 19200
 			}
 			FRA_412 = { add_core = GER }
@@ -84,10 +84,10 @@ political_decisions = {
 					NOT = { tag = LIE }
 					exists = yes
 				}
-				country_event = 99999			
+				country_event = 99999
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -106,7 +106,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	construct_germania_werft = {
 		picture = construct_germania_werft
 		potential = {
@@ -119,12 +119,12 @@ political_decisions = {
 			}
 			owns = 369
 		}
-		
+
 		allow = {
 			steel_steamers = 1
 			money = 51000
 		}
-		
+
 		effect = {
 			set_global_flag = germania_werft_has_been_built
 			prestige = 10
@@ -136,7 +136,7 @@ political_decisions = {
 						NOT = { has_building = aeroplane_factory }
 					}
 				}
-				owner = { 
+				owner = {
 					capital = 369
 					build_factory_in_capital_state = steamer_shipyard
 				}
@@ -187,7 +187,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	support_ruhr_industrialism = {
 		potential = {
 			OR = {
@@ -200,7 +200,7 @@ political_decisions = {
 				tech_school = prussian_tech_school
 			}
 		}
-		
+
 		allow = {
 			regenerative_furnaces = 1
 			iron_breech_loaded_artillery = 1
@@ -220,15 +220,15 @@ political_decisions = {
 				ai = yes
 			}
 		}
-		
+
 		effect = {
 			tech_school = prussian_tech_school
 			prestige = 5
 		}
-		
+
 		ai_will_do = { factor = 1 }
-	}	
-	
+	}
+
 	die_wacht_am_rhein = {
 		picture = die_wacht_am_rhein
 		potential = {
@@ -254,12 +254,12 @@ political_decisions = {
 				HES_2560 = { owner = { NOT = { is_culture_group = germanic } } }
 			}
 		}
-			
+
 		allow = {
 			romanticism = 1
 			ideological_thought = 1
 		}
-		
+
 		effect = {
 			prestige = 5
 			badboy = -1
@@ -272,34 +272,34 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	niederwald_denkmal = {
 		potential = {
-			OR = { 
+			OR = {
 				tag = GER
 				tag = GCF
 			}
 			has_global_flag = watching_the_rhine
 			NOT = { has_country_flag = niederwald_denkmal }
 		}
-		
+
 		allow = {
 			war = no
 			owns = 565
 			is_greater_power = yes
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			any_pop = { militancy = -2 }
 			badboy = -3
 			set_country_flag = niederwald_denkmal
 		}
 	}
-	
+
 	schwabing_circles = {
 		potential = {
 			OR = {
@@ -319,7 +319,7 @@ political_decisions = {
 			set_country_flag = schwabing_encircled
 		}
 	}
-	
+
 	support_biesterfelds = {
 		potential = {
 			tag = LIP
@@ -327,17 +327,17 @@ political_decisions = {
 			NOT = { has_country_flag = lippe_dispute_solved }
 			exists = PRU
 		}
-		
+
 		allow = {
 			is_independant = yes
 		}
-		
+
 		effect = {
 			prestige = 10
 			set_country_flag = lippe_dispute_solved
 		}
 	}
-	
+
 	support_schaumburgs = {
 		potential = {
 			tag = LIP
@@ -347,11 +347,11 @@ political_decisions = {
 			}
 			exists = PRU
 		}
-		
+
 		allow = {
 			is_independant = yes
 		}
-		
+
 		effect = {
 			relation = {
 				who = PRU
@@ -360,7 +360,7 @@ political_decisions = {
 			set_country_flag = lippe_dispute_solved
 		}
 	}
-	
+
 	das_zivilgesetzbuch = {
 		picture = das_zivilgesetzbuch
 		potential = {
@@ -369,11 +369,11 @@ political_decisions = {
 				has_country_flag = code_of_laws
 			}
 		}
-		
+
 		allow = {
 			ideological_thought = 1
 		}
-		
+
 		effect = {
 			prestige = 5
 			years_of_research = 0.05
@@ -397,11 +397,11 @@ political_decisions = {
 				has_global_flag = bismarck_islands_german
 			}
 		}
-		
+
 		allow = {
 			invention = mission_to_civilize
 		}
-		
+
 		effect = {
 			prestige = 10
 			1531 = { change_province_name = "Neu-Mecklenburg" }
@@ -416,7 +416,7 @@ political_decisions = {
 			set_global_flag = wir_wollen_unseren_alten_kaiser_wilhelm_wiederhaben
 		}
 	}
-	
+
 	the_heligoland_question = {
 		potential = {
 			OR = {
@@ -427,7 +427,7 @@ political_decisions = {
 			NOT = { has_country_flag = has_questioned_heligoland }
 			NOT = { has_country_flag = has_questioned_heligoland2 }
 		}
-		
+
 		allow = {
 			year = 1892
 			OR = {
@@ -442,7 +442,7 @@ political_decisions = {
 				owns = 2081
 			}
 		}
-		
+
 		effect = {
 			533 = {
 				add_core = THIS # Heligoland is my last territorial demand!
@@ -465,12 +465,12 @@ political_decisions = {
 			NOT = { has_country_flag = has_questioned_heligoland }
 			NOT = { has_country_flag = has_questioned_heligoland2 }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			war = no
 		}
-		
+
 		effect = {
 			prestige = 20
 			533 = {
@@ -678,11 +678,11 @@ political_decisions = {
 				has_global_flag = the_walhalla_is_built
 			}
 		}
-		
+
 		allow = {
 			romanticism = 1
 		}
-		
+
 		effect = {
 			prestige = 5
 			602 = {
@@ -694,7 +694,7 @@ political_decisions = {
 			set_global_flag = the_walhalla_is_built
 		}
 	}
-	
+
 	introduce_the_presbyteries = {
 		picture = introduce_the_presbyteries
 		potential = {
@@ -709,7 +709,7 @@ political_decisions = {
 				vassal_of = ENG
 			}
 		}
-		
+
 		effect = {
 			any_pop = {
 				limit = {
@@ -720,7 +720,7 @@ political_decisions = {
 			set_country_flag = presbyteries_introduced
 		}
 	}
-	
+
 	von_moltkes_staff_reforms = {
 		potential = {
 			OR = {
@@ -733,7 +733,7 @@ political_decisions = {
 			}
 		}
 		allow = {
-			OR = { 
+			OR = {
 				AND = {
 					breech_loaded_rifles = 1
 					army_professionalism = 1
@@ -760,7 +760,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	the_ruhr_boom = {
 		picture = essen_ruhr
 		potential = {
@@ -775,7 +775,7 @@ political_decisions = {
 			owns = 575
 			NOT = { has_global_flag = ruhr_boom_has_happened }
 		}
-		
+
 		allow = {
 			OR = {
 				AND = {
@@ -786,7 +786,7 @@ political_decisions = {
 				tech_school = prussian_tech_school
 			}
 		}
-		
+
 		effect = {
 			random_owned = {
 				limit = {
@@ -795,8 +795,8 @@ political_decisions = {
 						NOT = { has_building = steel_factory }
 					}
 				}
-				
-				owner = { 
+
+				owner = {
 					capital = 579
 					build_factory_in_capital_state = steel_factory
 				}
@@ -860,12 +860,12 @@ political_decisions = {
 			}
 			set_global_flag = ruhr_boom_has_happened
 		}
-		
-		ai_will_do = { 
-			factor = 1 
+
+		ai_will_do = {
+			factor = 1
 		}
 	}
-	
+
 	league_of_three_emperors = {
 		potential = {
 			tag = GER
@@ -894,7 +894,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = league_of_three_emperors }
 		}
-		
+
 		allow = {
 			revolution_n_counterrevolution = 1
 			war = no
@@ -903,14 +903,14 @@ political_decisions = {
 			NOT = { truce_with = RUS }
 			NOT = { war_with = RUS }
 		}
-		
+
 		effect = {
 			set_country_flag = league_of_three_emperors
 			AUS = { country_event = 33020 }
 			RUS = { country_event = 33020 }
 		}
 	}
-	
+
 	league_of_three_emperors2 = {
 		picture = league_of_three_emperors
 		potential = {
@@ -940,7 +940,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = league_of_three_emperors }
 		}
-		
+
 		allow = {
 			revolution_n_counterrevolution = 1
 			war = no
@@ -949,14 +949,14 @@ political_decisions = {
 			NOT = { truce_with = RUS }
 			NOT = { war_with = RUS }
 		}
-		
+
 		effect = {
 			set_country_flag = league_of_three_emperors
 			KUK = { country_event = 33020 }
 			RUS = { country_event = 33020 }
 		}
 	}
-	
+
 	reclaim_poland_GER = {
 		picture = become_poland
 		potential = {
@@ -973,7 +973,7 @@ political_decisions = {
 				699 = { NOT = { is_core = GER is_core = GCF } }
 			}
 		}
-		
+
 		allow = {
 			war = no
 			is_disarmed = no
@@ -997,7 +997,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			badboy = 5
 			random_owned = {
@@ -1042,7 +1042,7 @@ political_decisions = {
 				leave_alliance = THIS
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -1051,7 +1051,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	appoint_von_bismarck = {
 	picture = appoint_von_bismarck
 		potential = {
@@ -1068,7 +1068,7 @@ political_decisions = {
 				has_country_flag = von_bismarck_appointed
 			}
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -1081,7 +1081,7 @@ political_decisions = {
 				ruling_party_ideology = reactionary
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = von_bismarck_appointed
 			add_country_modifier = {
@@ -1101,10 +1101,10 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	reclaim_alsace_lorraine = {
 		picture = reichsland_elsass
 		potential = {
@@ -1116,7 +1116,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			tag = GER
 			is_greater_power = yes
@@ -1126,7 +1126,7 @@ political_decisions = {
 				412 = { owner = { war_with = THIS } }
 			}
 		}
-		
+
 		effect = {
 			clr_country_flag = lost_alsace_lorraine
 			badboy = 5
@@ -1150,20 +1150,20 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
 				badboy = 0.8
-			}	
+			}
 		}
 	}
-	
+
 	purchase_spanish_pacific = {
 		picture = treaty_signing
 		potential = {
-			OR = { 
+			OR = {
 				tag = GER
 				tag = GCF
 			}
@@ -1180,7 +1180,7 @@ political_decisions = {
 					NOT = { vassal_of = SPA }
 				}
 			}
-			OR = {		
+			OR = {
 				SPA = {
 					is_greater_power = no
 					any_owned_province = {
@@ -1205,7 +1205,7 @@ political_decisions = {
 				#any_owned_province = { continent = oceania }
 			}
 		}
-		
+
 		allow = {
 			money = 50000
 			OR = {
@@ -1220,7 +1220,7 @@ political_decisions = {
 				SPC = { war = yes }
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = tried_to_buy_spanish_pacific
 			random_country = {
@@ -1241,14 +1241,14 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	annex_limburg = {
 		picture = treaty_signing
 		potential = {
 			has_country_flag = limburg_crisis
 			LBG = { exists = yes }
 		}
-		
+
 		allow = {
 			war = no
 			is_sphere_leader_of = LBG
@@ -1257,7 +1257,7 @@ political_decisions = {
 				is_vassal = no
 			}
 		}
-		
+
 		effect = {
 			clr_country_flag = limburg_crisis
 			any_country = { clr_country_flag = limburg_crisis_NET }
@@ -1266,7 +1266,7 @@ political_decisions = {
 			inherit = LBG
 		}
 	}
-	
+
 	annex_sigmaringen = {
 		picture = declare_republic_of_neuchatel
 		potential = {
@@ -1279,7 +1279,7 @@ political_decisions = {
 			owns = 549
 			SGM = { exists = yes ai = yes owns = 594 }
 		}
-		
+
 		allow = {
 			war = no
 			is_sphere_leader_of = SGM
@@ -1299,7 +1299,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			diplomatic_influence = { who = SGM value = -400 }
 			release = SGM
@@ -1311,8 +1311,8 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
-	
+
+
 	access_to_the_rhine = {
 		picture = marching_soldiers
 		potential = {
@@ -1340,12 +1340,12 @@ political_decisions = {
 			NOT = { military_access = HEK }
 			NOT = { 566 = { is_core = THIS } }
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			badboy = 2
 			566 = { owner = { relation = { who = THIS value = -400 } leave_alliance = THIS } }
@@ -1362,8 +1362,8 @@ political_decisions = {
 		}
 	}
 
-	
-	
+
+
 
 #	sudeteland_exchange = {
 #		picture = treaty_signing
@@ -1380,21 +1380,21 @@ political_decisions = {
 #			owns = 2584
 #			NOT = { owns = 625 }
 #			NOT = { has_country_flag = sudeteland_treaty }
-#			625 = { 
-#				owner = { 
-#					ai = yes 
+#			625 = {
+#				owner = {
+#					ai = yes
 #					owns = 627
 #					owns = 628
 #					owns = 629
 #				}
 #			}
 #		}
-#		
+#
 #		allow = {
 #			war = no
 #			money = 45000
 #		}
-#		
+#
 #		effect = {
 #			set_country_flag = sudeteland_treaty
 #			625 = {
@@ -1413,7 +1413,7 @@ political_decisions = {
 #		}
 #	}
 
-	
+
 #from GCF.txt
 	# the_GCF_heligoland_question = {
 		# picture = the_heligoland_question
@@ -1423,14 +1423,14 @@ political_decisions = {
 				# has_country_flag = has_gcf_questioned_heligoland
 			# }
 		# }
-		
+
 		# allow = {
 			# OR = {
 				# is_greater_power = yes
 				# invention = national_fraternity
 			# }
 		# }
-		
+
 		# effect = {
 			# 533 = {
 				# add_core = GCF
@@ -1462,13 +1462,13 @@ political_decisions = {
 				owns = 2048 #Zanzibar
 			}
 			NOT = { has_country_flag = east_africa_company }
-			NOT = { invention = the_dark_continent } 
+			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
-			OR = { 
+			OR = {
 				year = 1884
 				steel_steamers = 1
 			}
@@ -1484,7 +1484,7 @@ political_decisions = {
 			NOT = { war_policy = pacifism }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			set_country_flag = east_africa_company
 			set_country_flag = german_east_africa_company
@@ -1503,7 +1503,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	purchase_lindi = {
 		picture = german_east_africa
 		potential = {
@@ -1529,14 +1529,14 @@ political_decisions = {
 			}
 			has_country_flag = east_africa_company
 			NOT = { has_country_flag = purchase_lindi }
-			NOT = { invention = the_dark_continent } 
+			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			is_disarmed = no
-			OR = { 
+			OR = {
 				year = 1884
 				steel_steamers = 1
 			}
@@ -1548,7 +1548,7 @@ political_decisions = {
 			NOT = { war_policy = pacifism }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			set_country_flag = purchase_lindi
 			random_country = {
@@ -1559,10 +1559,10 @@ political_decisions = {
 				country_event = 99840
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	german_west_africa = {
 		picture = german_west_africa
 		potential = {
@@ -1581,14 +1581,14 @@ political_decisions = {
 			has_global_flag = berlin_conference
 			NOT = { has_country_flag = german_west_africa }
 			1956 = { empty = yes }
-			NOT = { invention = the_dark_continent } 
+			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			is_disarmed = no
-			OR = { 
+			OR = {
 				year = 1884
 				steel_steamers = 1
 			}
@@ -1600,16 +1600,16 @@ political_decisions = {
 			NOT = { war_policy = pacifism }
 			NOT = { war_exhaustion = 5 }
 		}
-		
+
 		effect = {
 			treasury = -75000
 			set_country_flag = german_west_africa
 			badboy = 2
-			1956 = { 
-				secede_province = THIS 
-				any_pop = { literacy = -0.99 } 
-				change_province_name = "Duala" 
-			}		
+			1956 = {
+				secede_province = THIS
+				any_pop = { literacy = -0.99 }
+				change_province_name = "Duala"
+			}
 			1957 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			1958 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			1959 = { secede_province = THIS any_pop = { literacy = -0.99 } change_province_name = "Jaunde"	}
@@ -1619,10 +1619,10 @@ political_decisions = {
 			1963 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			1964 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	#Luderitz Expedition
 	luderitz_expedition = {
 		picture = luderitz_expedition
@@ -1639,10 +1639,10 @@ political_decisions = {
 			2077 = { empty = no }
 			year = 1850
 			slavery = no_slavery
-			NOT = { invention = the_dark_continent } 
+			NOT = { invention = the_dark_continent }
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			OR = {
@@ -1654,7 +1654,7 @@ political_decisions = {
 			nationalism_n_imperialism = 1
 			num_of_ports = 5
 			total_amount_of_ships = 55
-			OR = { 
+			OR = {
 				year = 1884
 				steel_steamers = 1
 			}
@@ -1666,7 +1666,7 @@ political_decisions = {
 		effect = {
 			prestige = 2
 			treasury = -50000
-			set_country_flag = founding_german_namibia 
+			set_country_flag = founding_german_namibia
 			2084 = { secede_province = THIS change_province_name = "Lüderitzbucht" any_pop = { literacy = -0.99 } life_rating = 21 }
 			2086 = { secede_province = THIS change_province_name = "Keetmanshoop" any_pop = { literacy = -0.99 } life_rating = 25 }
 			2085 = { secede_province = THIS change_province_name = "Maltahöhe" any_pop = { literacy = -0.99 } life_rating = 25 }
@@ -1676,7 +1676,7 @@ political_decisions = {
 			2082 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			NMB = { government = colonial_company }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -1692,10 +1692,10 @@ political_decisions = {
 			1915 = { empty = yes }
 			slavery = no_slavery
 			NOT = { has_global_flag = togo_organized }
-			has_global_flag = berlin_conference 
+			has_global_flag = berlin_conference
 			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			total_pops = 2000000
 			is_greater_power = yes
@@ -1731,16 +1731,16 @@ political_decisions = {
 			1917 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 25 }
 			1918 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 25 }
 			#random_owned = {
-			#	limit = { owner = { is_culture_group = germanic } } 
+			#	limit = { owner = { is_culture_group = germanic } }
 			#	owner = {
 			#		1915 = { change_province_name = "Misahöhe" }
 			#	}
 			#}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	form_mittelafrika = {
 		picture = "form_mittelafrika"
 		potential = {
@@ -1763,7 +1763,7 @@ political_decisions = {
 			1956 = { OR = { owned_by = THIS owner = { in_sphere = THIS vassal_of = THIS war = no } } } #Kameroon
 			NOT = { has_country_flag = form_mittelafrika }
 		}
-		
+
 		allow = {
 			war = no
 			invention = the_dark_continent
@@ -1781,7 +1781,7 @@ political_decisions = {
 			1819 = { OR = { owned_by = THIS owner = { in_sphere = THIS vassal_of = THIS war = no } } } #Waddai
 			1824 = { OR = { owned_by = THIS owner = { in_sphere = THIS vassal_of = THIS war = no } } } #Waddai
 		}
-		
+
 		effect = {
 			set_country_flag = form_mittelafrika
 			prestige = 15
@@ -1804,17 +1804,17 @@ political_decisions = {
 				value = 400
 			}
 			create_alliance = MAF
-			MAF = { 
+			MAF = {
 				prestige = -500
 				capital = 2036
 				government = colonial_company
 			}
 			TNZ = { all_core = { add_core = MAF } }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	return_cores_MIT = {
 		picture = return_cores_img
 		potential = {
@@ -1840,14 +1840,14 @@ political_decisions = {
 				TRZ = { all_core = { OR = { owned_by = THIS owner = { NOT = { tag = MAF } vassal_of = THIS war = no } } } }
 			}
 		}
-		
-		allow = { 
-			war = no 
-			MAF = { war = no } 
-		} 
-		
-		effect = {  
-			relation = { who = MAF value = 200 } 
+
+		allow = {
+			war = no
+			MAF = { war = no }
+		}
+
+		effect = {
+			relation = { who = MAF value = 200 }
 			any_owned = {
 				limit = {
 					OR = {
@@ -1863,10 +1863,10 @@ political_decisions = {
 			}
 			MAF = { prestige = -50 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-		
+
 	ober_ost = {
 		picture = ober_ost
 		potential = {
@@ -1892,7 +1892,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			revolution_n_counterrevolution = 1
@@ -1913,7 +1913,7 @@ political_decisions = {
 			}
 			NOT = { war_policy = pacifism }
 		}
-		
+
 		effect = {
 			badboy = 1
 			any_pop = { limit = { has_pop_culture = lithuanian } militancy = 5 }
@@ -2059,13 +2059,13 @@ political_decisions = {
 			}
 
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 #from FlavourMod_Ger.txt
 	build_reichstag = {
 		picture = "reichstag"
-		potential = { 
+		potential = {
 			OR = {
 				tag = GER
 				tag = GCF
@@ -2097,13 +2097,13 @@ political_decisions = {
 			}
 			set_country_flag = built_reichstag
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	berlin_baghdad_railway = {
 		picture = "berlin_baghdad"
-		potential = { 
+		potential = {
 			OR = {
 				tag = GER
 				tag = GCF
@@ -2136,10 +2136,10 @@ political_decisions = {
 		effect = {
 			country_event = 33005
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	franco_prussian_war_memorial = {
 		picture = "franco_prussian_memorial"
 		potential = {
@@ -2154,7 +2154,7 @@ political_decisions = {
 					has_global_flag = franco_prussian_memorial2
 				}
 			}
-			412 = { 
+			412 = {
 				OR = {
 					owned_by = THIS
 					owner = { vassal_of = THIS }
@@ -2163,12 +2163,12 @@ political_decisions = {
 		}
 		allow = {
 			war = no
-			OR = { 
-				AND = { 
+			OR = {
+				AND = {
 					truce_with = FRA
 					FRA = { has_recently_lost_war = yes }
 				}
-				AND = { 
+				AND = {
 					truce_with = BOR
 					BOR = { has_recently_lost_war = yes }
 				}
@@ -2185,18 +2185,18 @@ political_decisions = {
 					primary_culture = french
 					is_greater_power = yes
 					capital = 425
-				}	
+				}
 				country_event = 99932
 			}
 			set_global_flag = franco_prussian_memorial
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	franco_prussian_war_memorial2 = {  #Alternate Non-EMS Dispatch Unification Through an AI Freeing ALS, Allows AUS/BAV to use as well
 		picture = "franco_prussian_memorial"
-		potential = { 
+		potential = {
 			is_greater_power = yes
 			is_culture_group = germanic
 			ALS = { exists = yes }
@@ -2210,9 +2210,9 @@ political_decisions = {
 						is_vassal = no
 						vassal_of = THIS
 					}
-					NOT = { 
-						vassal_of = FRA 
-						vassal_of = BOR 
+					NOT = {
+						vassal_of = FRA
+						vassal_of = BOR
 					}
 					war = no
 					is_greater_power = no
@@ -2223,7 +2223,7 @@ political_decisions = {
 				BOR = { exists = yes truce_with = THIS }
 			}
 		}
-		
+
 		effect = {
 			badboy = -1
 			any_pop = {
@@ -2235,9 +2235,9 @@ political_decisions = {
 					primary_culture = french
 					is_greater_power = yes
 					capital = 425
-				}	
+				}
 				country_event = 99933
-			}			
+			}
 			diplomatic_influence = { who = ALS value = 400 }
 			ALS = {
 				any_pop = {
@@ -2254,22 +2254,22 @@ political_decisions = {
 							strata = middle
 							strata = rich
 							type = soldiers
-						}					
+						}
 					}
 					move_pop = 406
 				}
-				create_alliance = THIS				
+				create_alliance = THIS
 			}
 			set_global_flag = franco_prussian_memorial
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	treaty_of_vienna = {
 		picture = "form_germany"
-		potential = { 
-			OR = { 
+		potential = {
+			OR = {
 				tag = GER
 				AND = {
 					tag = GCF
@@ -2353,13 +2353,13 @@ political_decisions = {
 			}
 			set_global_flag = treaty_of_vienna
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	bohemian_question = {
 		picture = "czech_autonomy"
-		potential = { 
+		potential = {
 			OR = {
 				tag = GER
 				tag = GCF
@@ -2414,7 +2414,7 @@ political_decisions = {
 			relation = { who = BOH value = 50 }
 			diplomatic_influence = { who = BOH value = 400 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
@@ -2425,14 +2425,14 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	greater_germany_hungarian_border_treaty = {
 		picture = gtfo
 		potential = {
 			NOT = { has_country_flag = greater_germany_hungarian_border_treaty_tried }
-			OR = { 
+			OR = {
 				tag = GER
-				tag = GCF 
+				tag = GCF
 			}
 			HUN = { is_vassal = no }
 			OR = {
@@ -2448,15 +2448,15 @@ political_decisions = {
 				AND = {
 					is_greater_power = yes
 					state_n_government = 1
-					HUN = { 
+					HUN = {
 						in_sphere = THIS
-						is_greater_power = no 
+						is_greater_power = no
 					}
 				}
 			}
 			NOT = { has_global_flag = german_confederation_austrian }
-			NOT = { 
-				exists = AUS 
+			NOT = {
+				exists = AUS
 				exists = KUK
 			}
 			exists = HUN
@@ -2479,11 +2479,11 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		allow = {
 			war = no
 			state_n_government = 1
-			OR = { 
+			OR = {
 				AND = {
 					tag = GER
 					AUS_619 = { owned_by = THIS }
@@ -2510,7 +2510,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = greater_germany_hungarian_border_treaty_tried
 			random_country = {
@@ -2522,16 +2522,16 @@ political_decisions = {
 					exists = yes
 					neighbour = THIS
 				}
-				country_event = 60055559	
+				country_event = 60055559
 			}
 			624 = { add_core = THIS }
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	ger_ai_banat = {
 		picture = "treaty_signing"
-		potential = { 
+		potential = {
 			OR = {
 				government = absolute_monarchy
 				government = prussian_constitutionalism
@@ -2571,7 +2571,7 @@ political_decisions = {
 			war = no
 			has_recently_lost_war = no
 		}
-		
+
 		effect = {
 			badboy = 5
 			create_vassal = BAN
@@ -2587,13 +2587,13 @@ political_decisions = {
 			791 = {	secede_province = BAN }
 			set_country_flag = ger_ai_banat
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	dutch_prussian_alliance = {
 		picture = "treaty_signing"
-		potential = { 
+		potential = {
 			is_greater_power = yes
 			primary_culture = north_german
 			387 = { is_core = NET }
@@ -2601,13 +2601,13 @@ political_decisions = {
 			NOT = { has_global_flag = dutch_prussian_alliance }
 		}
 		allow = {
-			OR = {	
+			OR = {
 				war_with = BEL
 				truce_with = BEL
 			}
 			NET = { war_with = BEL }
 		}
-		
+
 		effect = {
 			badboy = 3
 			prestige = 10
@@ -2615,7 +2615,7 @@ political_decisions = {
 			set_global_flag = dutch_prussian_alliance
 		}
 	}
-	
+
 	treaty_of_amsterdamn = {
 		picture = "treaty_signing"
 		potential = {
@@ -2631,17 +2631,17 @@ political_decisions = {
 			NOT = { exists = BEL }
 			387 = { owned_by = NET }
 		}
-		
+
 		effect = {
 			badboy = 3
 			prestige = 10
 			NET = { country_event = 99958 }
 			set_global_flag = treaty_of_amsterdamn
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	the_jade_purchase = {
 		picture = "wilhelmshaven"
 		potential = {
@@ -2649,7 +2649,7 @@ political_decisions = {
 			NOT = { has_country_flag = has_asked_for_jade }
 			NOT = { owns = 3259 }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			money = 15000
@@ -2660,7 +2660,7 @@ political_decisions = {
 				year = 1853
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = has_asked_for_jade
 			random_owned = {
@@ -2674,10 +2674,10 @@ political_decisions = {
 			}
 			OLD = { country_event = 40001 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	rhineland_reacquire = {
 		picture = "rhineland"
 		potential = {
@@ -2691,7 +2691,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = rhineland_reacquired }
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -2706,20 +2706,20 @@ political_decisions = {
 			}
 			OR = { truce_with = FRA truce_with = BOR }
 		}
-		
+
 		effect = {
 			set_country_flag = rhineland_reacquired
 			inherit = RHI
 			badboy = -3
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	claim_liechenstein = {
 	picture = form_germany
 		potential = {
-			OR = { 
+			OR = {
 				tag = GER
 				tag = GCF
 			}
@@ -2734,7 +2734,7 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = claim_liechenstein }
 		}
-		
+
 		allow = {
 			war = no
 			LIE = {
@@ -2746,7 +2746,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = claim_liechenstein
 			LIE = {
@@ -2757,7 +2757,7 @@ political_decisions = {
 
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	become_schleswig = {
 		picture = gtfo
 		potential = {
@@ -2765,13 +2765,13 @@ political_decisions = {
 			any_owned_province = { is_core = HOL }
 			exists = HOL
 		}
-		
+
 		allow = {
 			owns = 369
 			owns = 370
 			NOT = { owns = 529 }
 		}
-		
+
 		effect = {
 			capital = 370
 			prestige = -5
@@ -2796,7 +2796,7 @@ political_decisions = {
 				capital = 369
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -2817,14 +2817,14 @@ political_decisions = {
 			NOT = { has_country_flag = begin_austro_prussian_war }
 			NOT = { has_country_flag = prussian_italian_alliance }
 		}
-		
+
 		allow = {
 			war = no
 			AUS = { war = no }
 			military_score = 100
 			has_recently_lost_war = no
 		}
-		
+
 		effect = {
 			set_country_flag = begin_austro_prussian_war
 			war = {
@@ -2834,13 +2834,13 @@ political_decisions = {
 				call_ally = yes
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
 				OR = {
-					AND = { 
+					AND = {
 						NOT = { year = 1866 }
 						NOT = { exists = ITA }
 					}
@@ -2852,7 +2852,7 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 	duchy_of_lorraine = {
 		picture = duchy_of_lorraine
 		potential = {
@@ -2868,7 +2868,7 @@ political_decisions = {
 			411 = { province_control_days = 365 }
 			NOT = { has_country_flag = duchy_of_lorraine }
 		}
-		
+
 		allow = {
 			war = no
 			413 = { OR = { has_pop_culture = north_german has_pop_culture = south_german } }
@@ -2884,7 +2884,7 @@ political_decisions = {
 				has_country_flag = prussian_settlement_commission
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = duchy_of_lorraine
 			FRA_411 = { add_core = LOR }
@@ -2909,10 +2909,10 @@ political_decisions = {
 				LOR = { government = prussian_constitutionalism }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	wilhelmshaven_imperial_shipyard = {
 		picture = wilhelmshaven_imperial_shipyard
 		potential = {
@@ -2923,14 +2923,14 @@ political_decisions = {
 			year = 1870
 			NOT = { 3259 = { state_scope = { has_building = steamer_shipyard } } }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			invention = steamer_shipyard_construction
 			steamers = 1
 			money = 51000
 		}
-		
+
 		effect = {
 			set_global_flag = wilhelmshaven_imperial_shipyard_built
 			treasury = -50000
@@ -2941,8 +2941,8 @@ political_decisions = {
 					province_id = 3259 #Wilhelmshaven
 					state_scope = { NOT = { has_building = steamer_shipyard } }
 				}
-				
-				owner = { 
+
+				owner = {
 					capital = 3259
 					build_factory_in_capital_state = steamer_shipyard
 				}
@@ -2985,10 +2985,10 @@ political_decisions = {
 				GCF = { capital = 619 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	danzig_imperial_shipyard = {
 		picture = danzig_imperial_shipyard
 		potential = {
@@ -3004,13 +3004,13 @@ political_decisions = {
 			battleship_column_doctrine = 1
 			NOT = { 690 = { state_scope = { has_building = steamer_shipyard } } }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			invention = steamer_shipyard_construction
 			money = 41000
 		}
-		
+
 		effect = {
 			set_global_flag = danzig_imperial_shipyard_built
 			treasury = -50000
@@ -3023,8 +3023,8 @@ political_decisions = {
 						NOT = { has_building = steamer_shipyard }
 					}
 				}
-				
-				owner = { 
+
+				owner = {
 					capital = 690
 					build_factory_in_capital_state = steamer_shipyard
 				}
@@ -3067,11 +3067,11 @@ political_decisions = {
 				owner = { capital = 619 }
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
-		
+
+
 	prussian_settlement_commission = {
 		picture = prussian_settlement_commission
 		potential = {
@@ -3086,7 +3086,7 @@ political_decisions = {
 			year = 1880
 			NOT = { has_country_flag = prussian_settlement_commission }
 		}
-		
+
 		allow = {
 			revolution_n_counterrevolution = 1
 			war = no
@@ -3102,7 +3102,7 @@ political_decisions = {
 			}
 			NOT = { accepted_culture = polish }
 		}
-		
+
 		effect = {
 			set_country_flag = prussian_settlement_commission
 			set_global_flag = germanization
@@ -3124,7 +3124,7 @@ political_decisions = {
 						region = PRU_682 #Lower Silesia
 						region = PRU_701 #Posen
 						region = PRU_690 #Westpreußen
-						
+
 					}
 				}
 				add_province_modifier = {
@@ -3134,16 +3134,16 @@ political_decisions = {
 				add_province_modifier = {
 					name = minority_building_restrictions
 					duration = 3650
-				}				
+				}
 			}
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 #from FlavourMod_Great_Eastern_Crisis.txt
 	the_reichstadt_agreement = {
 		picture = "congress_of_berlin"
-		potential = { 
+		potential = {
 			OR = {
 				tag = GER
 				tag = GCF
@@ -3162,7 +3162,7 @@ political_decisions = {
 				BOS = { vassal_of = TUR }
 			}
 			OR = {
-				AND = { 
+				AND = {
 					has_global_flag = constantinople_conference
 					RUS = { NOT = { war_with = TUR } }
 				}
@@ -3174,23 +3174,23 @@ political_decisions = {
 				has_global_flag = great_eastern_crisis_war_demanded_turks
 			}
 		}
-		
+
 		allow = {
-			NOT = { 
-				war_with = RUS 
+			NOT = {
+				war_with = RUS
 				truce_with = RUS
 			}
 			military_score = 100
 		}
-		
+
 		effect = {
 			set_global_flag = the_reichstadt_agreement
 			RUS = { country_event = 99822 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 #rename FlavourMod_ITA.txt
 	prussian_italian_alliance = {
 		picture = form_italy
@@ -3215,16 +3215,16 @@ political_decisions = {
 					owns = 726 #Milan
 				}
 			}
-			AUS = { 
+			AUS = {
 				owns = 729 #Venice
 			}
 			NOT = { has_country_flag = prussian_italian_alliance }
 		}
-		
+
 		allow = {
 			war = yes
 			OR = {
-				ITA = { 
+				ITA = {
 					war = no
 					exists = yes
 				}
@@ -3234,7 +3234,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = prussian_italian_alliance
 			any_country = {
@@ -3244,18 +3244,18 @@ political_decisions = {
 						tag = ITS
 					}
 				}
-				country_event = 99813 
+				country_event = 99813
 				set_country_flag = prussian_italian_alliance
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
 	}
-	
+
 #from FlavourMod_Qing
-	qingdao_treaty_port_ger = { 
+	qingdao_treaty_port_ger = {
 		picture = "qingdao_treaty_port_ger"
 		potential = {
 			OR = {
@@ -3271,13 +3271,14 @@ political_decisions = {
 				government = hms_government
 			}
 			NOT = { has_country_flag = qingdao_treaty_port_ger }
+			NOT = { has_global_flag = colonial_railroading_disabled }
 		}
-		
+
 		allow = {
 			steel_steamers = 1
 			1566 = { owner = { civilized = no } }
 		}
-		
+
 		effect = {
 			set_country_flag = qingdao_treaty_port_ger
 			1566 = { secede_province = THIS change_controller = THIS }
@@ -3288,7 +3289,7 @@ political_decisions = {
 				set_variable = { which = china_destablization value = 1 }
 			}
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
 #from GMU Germany.txt
@@ -3317,11 +3318,11 @@ political_decisions = {
 			NOT = { tag = KUK }
 			NOT = { has_country_flag = grunderzeit_we_have_done }
 		}
-		
+
 		allow = {
 			iron_railroad = 1
 		}
-		
+
 		effect = {
 			capital_scope = {
 				any_pop = {
@@ -3335,7 +3336,7 @@ political_decisions = {
 			prestige = 10
 			set_country_flag = grunderzeit_we_have_done
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -3348,25 +3349,25 @@ political_decisions = {
 			tag = GER
 			exists = AUS
 			is_sphere_leader_of = AUS
-			has_country_flag = brothers_war_winner 
+			has_country_flag = brothers_war_winner
 		}
-		
+
 		allow = {
 			war = no
 
 			NOT = {
 
-			has_global_flag = force_austria_to_join 			
+			has_global_flag = force_austria_to_join
 			}
 		}
-		
+
 		effect = {
 
 			AUS = {
 			country_event = 31515
 			}
 
-			set_country_flag = force_austria_to_join 
+			set_country_flag = force_austria_to_join
 		}
 		ai_will_do = { factor = 1 }
 	}
@@ -3378,25 +3379,25 @@ political_decisions = {
 			tag = GER
 			exists = KUK
 			is_sphere_leader_of = KUK
-			has_country_flag = brothers_war_winner 
+			has_country_flag = brothers_war_winner
 		}
-		
+
 		allow = {
 			war = no
 
 			NOT = {
 
-			has_global_flag = force_austria_to_join 			
+			has_global_flag = force_austria_to_join
 			}
 		}
-		
+
 		effect = {
 
 			KUK = {
 			country_event = 31515
 			}
 
-			set_country_flag = force_austria_to_join 
+			set_country_flag = force_austria_to_join
 		}
 		ai_will_do = { factor = 1 }
 	}
@@ -3412,7 +3413,7 @@ political_decisions = {
 			owns = 575
 			has_global_flag = dombau_beginn
 		}
-		
+
 		allow = {
 			year = 1860
 			money = 100001
@@ -3420,14 +3421,14 @@ political_decisions = {
 			nationalism_n_imperialism = 1
 			owns = 575
 		}
-		
+
 		effect = {
 			set_global_flag = cologne_cathedral_build
 			money = -100000
 			prestige = 25
 			THIS = { country_event = 200003 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -3450,7 +3451,7 @@ political_decisions = {
 			NOT = { press_rights = free_press }
 			ruling_party_ideology = liberal
 		}
-		
+
 		effect = {
 			set_country_flag = free_press_in_baden
 			prestige = 5
@@ -3458,7 +3459,7 @@ political_decisions = {
 			AUS = {	country_event = 200017 }
 			PRU = {	country_event = 200017 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -3480,7 +3481,7 @@ political_decisions = {
 			romanticism = 1
 			money = 5000
 		}
-		
+
 		effect = {
 			set_global_flag = goethe_denkmal_build
 			prestige = 10
@@ -3514,7 +3515,7 @@ political_decisions = {
 				country_event = 200033
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -3536,7 +3537,7 @@ political_decisions = {
 			romanticism = 1
 			money = 15000
 		}
-		
+
 		effect = {
 			set_global_flag = schiller_denkmal_build
 			prestige = 10
@@ -3561,7 +3562,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -3574,7 +3575,7 @@ political_decisions = {
 	build_maximilianstrasse = {
 		picture = "build_maximilianstrasse"
 		potential = {
-			OR = { 
+			OR = {
 				tag = BAV
 				AND = {
 					NOT = { tag = BAV }
@@ -3589,24 +3590,24 @@ political_decisions = {
 			romanticism = 1
 			invention = populism_vs._establishment
 			money = 55000
-			OR = { 
+			OR = {
 				government = absolute_monarchy
 				government = prussian_constitutionalism
 				government = hms_government
 			}
 		}
-		
+
 		effect = {
 			set_global_flag = maximilianstrasse_build
 			treasury = -55000
 			prestige = 10
 			599 = { life_rating = 3 }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 		}
-   }		
+   }
 	form_south_german_confederation = {
 		potential = {
 			capital_scope = { continent = europe }
@@ -3647,7 +3648,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			clr_country_flag = crown_from_the_gutter
 			clr_country_flag = secondary_union_formation
@@ -3739,13 +3740,13 @@ political_decisions = {
 					vassal_of = GER
 				}
 				SIE = { exists = no }
-			}	
+			}
 			OR = {
 				SLV = {
 					vassal_of = GER
 				}
 				SLV = { exists = no }
-			}				
+			}
 			652 = {
 				owned_by = THIS
 			}
@@ -3759,7 +3760,7 @@ political_decisions = {
 				owned_by = THIS
 			}
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			prestige = 500
@@ -3767,9 +3768,9 @@ political_decisions = {
 				government = absolute_monarchy
 				government = prussian_constitutionalism
 				government = hms_government
-			}	
+			}
 		}
-		
+
 		effect = {
 			badboy = 16
 			prestige = 50
@@ -3781,7 +3782,7 @@ political_decisions = {
 			623 = {
 				add_core = GER
 			}
-		}	
+		}
 	}
 #from MiniMod-HNS
 	reform_hansa = {
@@ -3813,9 +3814,9 @@ political_decisions = {
 						}
 						war = no
 					}
-				}	
+				}
 			}
-			539 = {	
+			539 = {
 				OR = {
 					owned_by = THIS
 					owner = {
@@ -3825,9 +3826,9 @@ political_decisions = {
 						}
 						war = no
 					}
-				}	
+				}
 			}
-			528 = {	
+			528 = {
 				OR = {
 					owned_by = THIS
 					owner = {
@@ -3837,9 +3838,9 @@ political_decisions = {
 						}
 						war = no
 					}
-				}	
+				}
 			}
-			690 = {	
+			690 = {
 				OR = {
 					owned_by = THIS
 					owner = {
@@ -3849,14 +3850,14 @@ political_decisions = {
 						}
 						war = no
 					}
-				}	
-			}			
+				}
+			}
 		}
 
 		effect = {
 			badboy = 8
 			prestige = 20
-			set_country_flag = reform_hansa	
+			set_country_flag = reform_hansa
 			530 = {
 				add_core = HNS
 			}
@@ -3890,7 +3891,7 @@ political_decisions = {
 			349 = {
 				add_core = HNS
 			}
-			change_tag = HNS		
+			change_tag = HNS
 			any_country = {
 				limit = {
 					tag = HAM
@@ -3935,15 +3936,15 @@ political_decisions = {
 					secede_province = THIS
 				}
 			}
-			capital = 530		
+			capital = 530
 		}
-		
+
 		ai_will_do = {
 			factor = 1
 			modifier = {
 				factor = 0
 				badboy = 0.50
-			}		
+			}
 		}
 	}
 #from MISC_Flavour.txt
@@ -3951,8 +3952,8 @@ political_decisions = {
 		picture = neuschwanstein
 		potential = {
 			year = 1886
-			OR = { 
-				AND = { 
+			OR = {
+				AND = {
 					tag = BAV
 					has_country_flag = swan_king
 				}
@@ -3969,24 +3970,24 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = neuschwanstein_built }
 		}
-		
+
 		allow = {
-			OR = { 
+			OR = {
 				is_greater_power = yes
 				is_secondary_power = yes
 			}
 			romanticism = 1
 		}
-		
+
 		effect = {
 			treasury = -30000 #It costed 6.2 million marks but I have no idea how that translates into game money.
 			prestige = 15
 			set_global_flag = neuschwanstein_built
 		}
-			
+
 		ai_will_do = { factor = 1 }
 	}
-#from more decisions	
+#from more decisions
 	treaty_of_elass_lorraine = {
 		picture = duchy_of_lorraine
 		potential = {
@@ -4005,7 +4006,7 @@ political_decisions = {
 			410 = { is_core = FRA }
 			409 = { is_core = FRA }
 			412 = { is_core = FRA }
-			OR = { 
+			OR = {
 				war_policy = anti_military
 				war_policy = pacifism
 			}
@@ -4034,7 +4035,7 @@ political_decisions = {
 			factor = 1
 		}
 	}
-	
+
 	GER_cancel_elasstreaty = {
 		picture = swastika
 		potential = {
@@ -4071,20 +4072,20 @@ political_decisions = {
 			set_global_flag = elass_lorraine_null
 			prestige = 10
 			FRA_412 = { add_core = THIS }
-			FRA = { 
+			FRA = {
 				country_event = 2317187
 			}
-			move_issue_percentage = { 
-				from = pro_military 
+			move_issue_percentage = {
+				from = pro_military
 				to = jingoism
 				value = 0.25
 			}
-			move_issue_percentage = { 
-				from = anti_military 
+			move_issue_percentage = {
+				from = anti_military
 				to = pro_military
 				value = 0.25
 			}
-			
+
 		}
 		ai_will_do = {
 			factor = 1
@@ -4140,7 +4141,7 @@ political_decisions = {
 
 			NOT = { exists = LUX }
 			NOT = { exists = WLL }
-	
+
 		}
 
 		allow = {
@@ -4183,13 +4184,13 @@ political_decisions = {
 
 			NOT = { has_country_flag = annexed_nm }
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			exists = MRN
 			war = no
 		}
-		
+
 		effect = {
 			inherit = MRN
 			prestige = 2
@@ -4197,7 +4198,7 @@ political_decisions = {
 				remove_core = MRN
 			}
 
-			set_country_flag = annexed_nm 
+			set_country_flag = annexed_nm
 		}
 	}
 
@@ -4210,9 +4211,9 @@ political_decisions = {
 			OR = {
 					exists = POL
 					exists = CPL
-			}		
+			}
 		}
-		
+
 		allow = {
 			is_greater_power = yes
 			OR = {
@@ -4221,11 +4222,11 @@ political_decisions = {
 			}
 			war = no
 		}
-		
+
 		effect = {
 			717 = {
 				secede_province = GER }
-			717 = {	
+			717 = {
 				change_province_name = "Kalisch"}
 			POL = {
 				relation = { who = GER value = -50 }
@@ -4248,11 +4249,11 @@ political_decisions = {
 			relation = { who = NOR value = 150 }
 			NOR= { in_sphere = THIS }
 		}
-		
+
 		effect = {
-			set_global_flag = bergen_leased 
+			set_global_flag = bergen_leased
 			badboy = 1
-			NOR = { country_event = 11011 }	
+			NOR = { country_event = 11011 }
 			}
 		}
 
@@ -4274,12 +4275,12 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = create_reichspakt }
 		}
-		
+
 		allow = {
 			money = 35000
 			war = no
 		}
-		
+
 		effect = {
 		    set_global_flag = german_welcomes_eastern_workers
 			add_country_modifier = {
@@ -4298,7 +4299,7 @@ political_decisions = {
 					duration = -1
 				}
 			}
-			money = -35000		
+			money = -35000
 		}
 		ai_will_do = { factor = 0.1 }
 	}
@@ -4319,12 +4320,12 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			alliance_with = UKR
 		}
-		
+
 		allow = {
 			money = 35000
 			war = no
 		}
-		
+
 		effect = {
 		    set_global_flag = eastern_grain
 			add_country_modifier = {
@@ -4343,7 +4344,7 @@ political_decisions = {
 					duration = -1
 				}
 			}
-			money = -35000		
+			money = -35000
 		}
 		ai_will_do = { factor = 0.1 }
 	}
@@ -4368,7 +4369,7 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_country_flag = germanize_the_netherlands }
 		}
-		
+
 		allow = {
 			war = no
 			385 = { province_control_days = 5475 }
@@ -4382,7 +4383,7 @@ political_decisions = {
 			388 = { province_control_days = 5475 }
 			397 = { province_control_days = 5475 }
 		}
-		
+
 		effect = {
 			set_country_flag = germanize_the_netherlands
 			NET_375 = { add_core = GER }
@@ -4391,10 +4392,10 @@ political_decisions = {
 			BEL_387 = { add_core = GER }
 			400 = { add_core = GER }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	standard_german = {
 		picture = german_tyrol
 		potential = {
@@ -4404,21 +4405,21 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_country_flag = South-German-Assimilation }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			country_event = {
 				id = 9212121
 				days = 0
 			}
 		}
-		
+
 		ai_will_do = { factor = 0.05 }
 	}
-	
+
 	host_german_royal_family = {
 		picture = german_east_africa
 		potential = {
@@ -4427,7 +4428,7 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = host_german_royal_family }
 		}
-		
+
 		allow = {
 			GER = {
 				OR = {
@@ -4437,7 +4438,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			GER = { release = NMB }
 			set_global_flag = host_german_royal_family
@@ -4457,12 +4458,12 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = greatest_germany }
 		}
-		
+
 		allow = {
 			war = no
 			ai = no
 		}
-		
+
 		effect = {
 			country_event = {
 				id = 9111111
@@ -4484,13 +4485,13 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = establish_greatest_germany }
 		}
-		
+
 		allow = {
 			war = no
 			SWI = { in_sphere = GER }
 			DEN = { in_sphere = GER }
 		}
-		
+
 		effect = {
 			set_global_flag = establish_greatest_germany
 			inherit = SWI
@@ -4503,7 +4504,7 @@ political_decisions = {
 			251 = {	secede_province = USA }
 			2636 = {	secede_province = USA }
 			random_country = {
-				limit = { 
+				limit = {
 					exists = BOR
 				}
 				607 = { secede_province = BOR }
@@ -4515,7 +4516,7 @@ political_decisions = {
 				SWI_607 = { add_core = BOR }
 			}
 			random_country = {
-				limit = { 
+				limit = {
 					exists = FRA
 				}
 				607 = { secede_province = FRA }
@@ -4527,21 +4528,21 @@ political_decisions = {
 				SWI_607 = { add_core = FRA }
 			}
 			random_country = {
-				limit = { 
+				limit = {
 					exists = SAR
 				}
 				2568 = { secede_province = SAR }
 				SWI_2568 = { add_core = SAR }
 			}
 			random_country = {
-				limit = { 
+				limit = {
 					exists = ITA
 				}
 				2568 = { secede_province = ITA }
 				SWI_2568 = { add_core = ITA }
 			}
 			random_country = {
-				limit = { 
+				limit = {
 					exists = ITS
 				}
 				2568 = { secede_province = ITS }
@@ -4552,7 +4553,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 0.5 }
 	}
-	
+
 	annex_holstein = {
 		picture = golden_law
 		potential = {
@@ -4561,7 +4562,7 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = resolved_schleswigholstein }
 		}
-		
+
 		allow = {
 			OR = {
 				AND = {
@@ -4574,7 +4575,7 @@ political_decisions = {
 				DEN = { war_exhaustion = 50 }
 			}
 		}
-		
+
 		effect = {
 		    set_global_flag = resolved_schleswigholstein
 			end_war = DEN
@@ -4584,7 +4585,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 0 }
 	}
-	
+
 	annex_holsteinandflensburg = {
 		picture = golden_law
 		potential = {
@@ -4593,7 +4594,7 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = resolved_schleswigholstein }
 		}
-		
+
 		allow = {
 			OR = {
 				AND = {
@@ -4606,7 +4607,7 @@ political_decisions = {
 				DEN = { war_exhaustion = 50 }
 			}
 		}
-		
+
 		effect = {
 			371 = { change_province_name = "Aabenraa" }
 		    set_global_flag = resolved_schleswigholstein
@@ -4618,7 +4619,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 0 }
 	}
-	
+
 	annex_scbleswigholstein = {
 		picture = golden_law
 		potential = {
@@ -4627,7 +4628,7 @@ political_decisions = {
 			NOT = { has_global_flag = disable_GEF }
 			NOT = { has_global_flag = resolved_schleswigholstein }
 		}
-		
+
 		allow = {
 			OR = {
 				AND = {
@@ -4640,7 +4641,7 @@ political_decisions = {
 				DEN = { war_exhaustion = 50 }
 			}
 		}
-		
+
 		effect = {
 		    set_global_flag = resolved_schleswigholstein
 			DEN = { inherit = SWH }
@@ -4655,7 +4656,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 0 }
 	}
-	
+
 #from Vichy France.txt
 	the_french_menace = {
 		picture = swastika
@@ -4673,9 +4674,9 @@ political_decisions = {
 			government = fascist_dictatorship
 			412 = { NOT = { owned_by = THIS } }
 		}
-		
+
 		allow = { war = no }
-		
+
 		effect = {
 			set_country_flag = the_french_menace
 			badboy = 50
@@ -4703,11 +4704,11 @@ political_decisions = {
 					}
 				}
 			}
-			
+
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	vichy_france = {
 		picture = vf_symbol
 		potential = {
@@ -4726,11 +4727,11 @@ political_decisions = {
 			BOR = { exists = no }
 			425 = { owned_by = THIS }
 		}
-		
+
 		allow = {
 			war = no
 		}
-		
+
 		effect = {
 			set_country_flag = vf_released
 			badboy = -10
@@ -4774,21 +4775,21 @@ political_decisions = {
 			release_vassal = VIC
 			relation = { who = VIC value = 400 }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 	#from Setup.txt
-	
+
 	literacy_PRU = {
 		potential = {
 			tag = PRU
 			always = no
 		}
-		
+
 		allow = {
 			tag = PRU
 		}
-		
+
 		effect = {
 			any_pop = {
 				limit = { has_pop_culture = ashkenazi }
@@ -4830,20 +4831,20 @@ political_decisions = {
 				limit = { has_pop_culture = lithuanian }
 				literacy = 0.50
 			}
-			
+
 			565 = { any_pop = { limit = { has_pop_religion = catholic } literacy = -0.05 } }
 			564 = { any_pop = { limit = { has_pop_religion = catholic } literacy = -0.05 } }
-			
+
 			add_country_modifier = {
 				name = zollervein
 				duration = -1
 			}
-			
+
 			add_country_modifier = {
 				name = global_baby_boom
 				duration = 3650
 			}
-			
+
 			FRM = {
 				any_owned = {
 					add_province_modifier = {
@@ -4896,19 +4897,19 @@ political_decisions = {
 			has_country_flag = neuchatel_crisis_escalated
 			NCT = { exists = yes }
 		}
-		
+
 		allow = {
 			war = no
 			NCT = { war = no }
 			NCT = {
-				exists = yes NOT = { vassal_of = SWI } 
+				exists = yes NOT = { vassal_of = SWI }
 				OR = {
 					in_sphere = THIS
 					NOT = { part_of_sphere = yes }
 				}
 			}
 		}
-		
+
 		effect = {
 			clr_country_flag = neuchatel_crisis_escalated
 			any_country = { clr_country_flag = neuchatel_crisis_escalated }
@@ -4919,7 +4920,7 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	force_neuchatel_issue = {
 		picture = declare_republic_of_neuchatel
 		potential = {
@@ -4934,13 +4935,13 @@ political_decisions = {
 			}
 			NCT = { exists = yes }
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 			608 = { is_core = THIS }
 		}
-		
+
 		effect = {
 			country_event = 34615
 			set_country_flag = neuchatel_crisis_escalated
@@ -4951,14 +4952,14 @@ political_decisions = {
 #from FlavourMod_Baltics
 	annex_united_baltic_duchy = {
 		picture = "annex_united_baltic_duchy"
-		potential = { 
+		potential = {
 			OR = {
 				tag = GCF
 				tag = GER
 			}
 			is_greater_power = yes
 			UBD = {
-				vassal_of = THIS 
+				vassal_of = THIS
 				ai = yes
 				exists = yes
 			}
@@ -4969,9 +4970,9 @@ political_decisions = {
 			}
 			NOT = { has_global_flag = annex_baltic_duchy }
 		}
-		
+
 		allow = {
-			war = no 
+			war = no
 			has_recently_lost_war = no
 			is_sphere_leader_of = UBD
 			nationalism_n_imperialism = 1
@@ -4983,9 +4984,9 @@ political_decisions = {
 					}
 					is_greater_power = yes
 				}
-				AND = { 
-					UBD = { 
-						vassal_of = THIS 
+				AND = {
+					UBD = {
+						vassal_of = THIS
 						NOT = { has_country_modifier = drang_nach_osten_country }
 					}
 					has_country_flag = incorporate_the_baltic_states
@@ -4998,7 +4999,7 @@ political_decisions = {
 			}
 			NOT = { war_policy = pacifism }
 		}
-		
+
 		effect = {
 			badboy = 2
 			diplomatic_influence = { who = UBD value = -400 }
@@ -5033,18 +5034,18 @@ political_decisions = {
 		}
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	incorporate_the_baltic_states = {
 		picture = "annex_united_baltic_duchy"
 		potential = {
-			is_greater_power = yes	
-			OR = { 
+			is_greater_power = yes
+			OR = {
 				tag = GER
 				tag = GCF
 			}
 			exists = UBD
 			UBD = {
-				OR = { 
+				OR = {
 					is_vassal = no
 					is_substate = no
 					vassal_of = THIS
@@ -5054,12 +5055,12 @@ political_decisions = {
 			}
 			NOT = { has_country_flag = incorporate_the_baltic_states }
 		}
-		
+
 		allow = {
 			war = no
 			nationalism_n_imperialism = 1
 		}
-		
+
 		effect = {
 			badboy = 2
 			prestige = 10
@@ -5075,14 +5076,14 @@ political_decisions = {
 				}
 			}
 			random_owned = { limit = { owner = { vote_franschise = none_voting } }
-				UBD = { 
-					government = colonial_company 
-					political_reform = none_voting 
-				} 
+				UBD = {
+					government = colonial_company
+					political_reform = none_voting
+				}
 			}
 			random_owned = { limit = { owner = { NOT = { vote_franschise = none_voting } } UBD = { government = dominion } } }
 			set_country_flag = incorporate_the_baltic_states
 		}
 		ai_will_do = { factor = 1 }
-	}	
+	}
 }

--- a/TGC/decisions/Treaty_Ports.txt
+++ b/TGC/decisions/Treaty_Ports.txt
@@ -5,18 +5,18 @@ political_decisions = {
 			has_country_modifier = negotiating_treaty
 			1695 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1695 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	qeshm_treaty_port = {
 		picture = qeshm_iran
 		potential = {
@@ -24,17 +24,18 @@ political_decisions = {
 			1071 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_global_flag = qeshm_treaty_port_alternate }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1071 = { secede_province = THIS change_controller = THIS }
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	qeshm_treaty_port_alternate = {
 		picture = qeshm_iran
 		potential = {
@@ -50,10 +51,10 @@ political_decisions = {
 			exists = PER
 			NOT = { has_global_flag = qeshm_treaty_port_alternate }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			set_global_flag = qeshm_treaty_port_alternate
 			badboy = -3
@@ -68,11 +69,11 @@ political_decisions = {
 				secede_province = PER
 			}
 			1071 = { secede_province = THIS change_controller = THIS }
-			
 		}
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	macao_treaty_port = {
 		picture = macao_china
 		potential = {
@@ -80,10 +81,9 @@ political_decisions = {
 			1498 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1498 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -91,38 +91,39 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	hong_kong_treaty_port = {
 		picture = hong_kong_china
 		potential = {
@@ -130,47 +131,47 @@ political_decisions = {
 			1496 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1496 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
 			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
 			1493 = { remove_province_modifier = canton_system }
+			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	shanghai_treaty_port = {
 		picture = shanghai_china
-		
+
 		potential = {
-			has_country_modifier = negotiating_treaty	
+			has_country_modifier = negotiating_treaty
 			1538 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1538 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -178,43 +179,44 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					NOT = { has_country_flag = treaty_of_tientsin }
-					QNG = {
-						exists = yes
-						owns = 1496
-					}
-					1496 = { owner = { civilized = no truce_with = THIS } }
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				NOT = { has_country_flag = treaty_of_tientsin }
+				QNG = {
+					exists = yes
+					owns = 1496
 				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+				1496 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
 		}
 	}
-	
+
 	qingdao_treaty_port = {
 		picture = qingdao_china
 		potential = {
 			OR = {
-				has_global_flag = colonial_railroading_disabled 
+				has_global_flag = colonial_railroading_disabled
 				tag = NGF
 				tag = GER
 				tag = GCF
@@ -223,10 +225,9 @@ political_decisions = {
 			1566 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1566 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -234,45 +235,46 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}	
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	lushun_treaty_port = {
 		picture = port_arthur
 		potential = {
@@ -280,10 +282,9 @@ political_decisions = {
 			1481 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1481 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -291,37 +292,38 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}	
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	weihaiwei_treaty_port = {
 		picture = weihaiwei_china
 		potential = {
@@ -333,10 +335,9 @@ political_decisions = {
 				tag = ENG
 			}
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1569 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -344,40 +345,41 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	jiaxing_treaty_port = {
 		picture = jiaxing_china
 		potential = {
@@ -385,10 +387,9 @@ political_decisions = {
 			1606 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1606 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -396,45 +397,46 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	taipei_treaty_port = {
 		picture = taipei_china
 		potential = {
@@ -445,14 +447,14 @@ political_decisions = {
 			2681 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
+
 		allow = {
 			OR = {
 				capital_scope = { continent = asia }
 				invention = radio_telegraphy
 			}
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			2406 = { secede_province = THIS change_controller = THIS }
@@ -463,36 +465,36 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
-		
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}	
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	hainan_treaty_port = {
 		picture = hainan_china
 		potential = {
@@ -500,10 +502,9 @@ political_decisions = {
 			1499 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1499 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -511,45 +512,46 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}	
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-	
+
 	kwangchowan_treaty_port = {
 		picture = kwangchowan_china
 		potential = {
@@ -564,10 +566,9 @@ political_decisions = {
 			2632 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			2632 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -575,45 +576,46 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}	
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
-		
+
 	ningbo_treaty_port = {
 		picture = ningbo_china
 		potential = {
@@ -621,10 +623,9 @@ political_decisions = {
 			1608 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1608 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -632,37 +633,38 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no truce_with = THIS } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no truce_with = THIS } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
 	}
 
 	tianjin_treaty_port = {
@@ -673,10 +675,9 @@ political_decisions = {
 			3249 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 			NOT = { has_country_modifier = chinese_treaty_port }
 		}
-		
-		allow = {
-		}
-		
+
+		allow = { }
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			3249 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
@@ -684,148 +685,253 @@ political_decisions = {
 			1493 = { remove_province_modifier = canton_system }
 			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
 		}
+
 		ai_will_do = {
 			factor = 1
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1496 }
-					1496 = { owner = { civilized = no } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1569 }
-					1569 = { owner = { civilized = no } }
-				}
-				modifier = {
-					factor = 0
-					tag = ENG
-					NOT = { owns = 1566 }
-					1566 = { owner = { civilized = no } }
-				}
-				modifier = {
-					factor = 0
-					tag = RUS
-					NOT = { owns = 1481 }
-					1481 = { owner = { civilized = no } }
-				}
-				modifier = {
-					factor = 0
-					primary_culture = japanese
-					NOT = { owns = 1415 }
-					1481 = { owner = { civilized = no } }
-					NOT = { owns = 1485 }
-					1485 = { owner = { civilized = no } }
-					NOT = { owns = 2562 }
-					2562 = { owner = { civilized = no } }
-				}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no } }
 			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1566 }
+				1566 = { owner = { civilized = no } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no } }
+			}
+		}
 	}
-	
+
+	san_mun_treaty_port = {
+		picture = dreams_of_empire
+		potential = {
+			has_country_modifier = negotiating_treaty
+			3326 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
+			NOT = { has_country_modifier = chinese_treaty_port }
+		}
+
+		allow = {
+		}
+
+		effect = {
+			remove_country_modifier = negotiating_treaty
+			3326 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
+			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
+			1493 = { remove_province_modifier = canton_system }
+			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
+	}
+
+	fuzhou_treaty_port = {
+		picture = dreams_of_empire
+		potential = {
+			has_country_modifier = negotiating_treaty
+			1482 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
+			NOT = { has_country_modifier = chinese_treaty_port }
+		}
+
+		allow = {
+		}
+
+		effect = {
+			remove_country_modifier = negotiating_treaty
+			1482 = { secede_province = THIS change_controller = THIS add_province_modifier = { name = treaty_port duration = -1 } }
+			add_country_modifier = { name = chinese_treaty_port duration = 1095 }
+			1493 = { remove_province_modifier = canton_system }
+			random_country = { limit = { tag = QNG exists = yes } set_variable = { which = china_destablization value = 1 } }
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1496 }
+				1496 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = ENG
+				NOT = { owns = 1569 }
+				1569 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				tag = RUS
+				NOT = { owns = 1481 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+			}
+			modifier = {
+				factor = 0
+				primary_culture = japanese
+				NOT = { owns = 1415 }
+				1481 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 1485 }
+				1485 = { owner = { civilized = no truce_with = THIS } }
+				NOT = { owns = 2562 }
+				2562 = { owner = { civilized = no truce_with = THIS } }
+			}
+		}
+	}
+
 	gwadar_treaty_port = {
 		picture = gwadar_pakistan
 		potential = {
 			has_country_modifier = negotiating_treaty
 			2640 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			2640 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	socotra_treaty_port = {
 		picture = socotra_yemen
 		potential = {
 			has_country_modifier = negotiating_treaty
 			1177 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1177 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	zanzibar_treaty_port = {
 		picture = zanzibar_oman
 		potential = {
 			has_country_modifier = negotiating_treaty
 			2048 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			2048 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	cheju_treaty_port = {
 		picture = cheju_korea
 		potential = {
 			has_country_modifier = negotiating_treaty
 			1637 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = {
 		}
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			1637 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	tsushima_treaty_port = {
 		picture = tsushima_japan
 		potential = {
 			has_country_modifier = negotiating_treaty
 			2589 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = { }
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			2589 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
-	
+
 	sado_treaty_port = {
 		picture = sado_japan
 		potential = {
 			has_country_modifier = negotiating_treaty
 			3260 = { owner = { has_country_modifier = negotiating_unequal_treaty civilized = no truce_with = THIS } }
 		}
-		
+
 		allow = { }
-		
+
 		effect = {
 			remove_country_modifier = negotiating_treaty
 			3260 = { secede_province = THIS change_controller = THIS }
 		}
-		
+
 		ai_will_do = { factor = 1 }
 	}
 
@@ -838,7 +944,7 @@ political_decisions = {
 			exists = yes
 			NOT = { is_culture_group = east_asian }
 		}
-		
+
 		allow = {
 			war = no
 			OR = {
@@ -858,7 +964,7 @@ political_decisions = {
 				}
 			}
 		}
-		
+
 		effect = {
 			set_country_flag = demanded_port_arthur
 			badboy = 1
@@ -873,5 +979,5 @@ political_decisions = {
 			}
 		}
 	}
-	
+
 }

--- a/TGC/events/CivilizationAndGunBoats.txt
+++ b/TGC/events/CivilizationAndGunBoats.txt
@@ -11,11 +11,11 @@ country_event = {
 	title = "EVTNAME13000"
 	desc = "EVTDESC13000"
 	picture = "Western"
-	
+
 	trigger = {
 		civilized = no
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		NOT = {
@@ -33,11 +33,11 @@ country_event = {
 			year = 1837
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 6
 	}
-	
+
 	option = {
 		name = "EVTOPTA13000"
 		add_country_modifier = {
@@ -106,10 +106,10 @@ country_event = {
 	title = "EVTNAME13010"
 	desc = "EVTDESC13010"
 	picture = "Thermopylae"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = { is_coastal = yes }
@@ -122,7 +122,7 @@ country_event = {
 			NOT = { has_province_modifier = western_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 120
 		modifier = {
@@ -166,7 +166,7 @@ country_event = {
 			num_of_ports = 50
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13010"
 		random_owned = {
@@ -180,14 +180,14 @@ country_event = {
 				add_country_modifier = { name = western_influences duration = -1 }
 			}
 		}
-		
+
 		random_owned = {
 			limit = { NOT = { owner = { is_culture_group = east_asian } } }
 			owner = {
-				
+
 			}
 		}
-		
+
 		ai_chance = {
 			factor = 25
 			modifier = {
@@ -230,10 +230,10 @@ country_event = {
 	title = "EVTNAME13015"
 	desc = "EVTDESC13015"
 	picture = "arrested"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -252,7 +252,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
 		modifier = {
@@ -300,7 +300,7 @@ country_event = {
 			num_of_ports = 50
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13015"
 		random_owned = {
@@ -327,7 +327,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13015"
 		treasury = 5000
@@ -357,10 +357,10 @@ country_event = {
 	title = "EVTNAME13016"
 	desc = "EVTDESC13016"
 	picture = "Opium"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 			has_country_flag = treaty_of_macao
 		}
@@ -371,7 +371,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 120
 		modifier = {
@@ -382,13 +382,13 @@ country_event = {
 			factor = 0.8
 			has_country_modifier = trade_restrictions
 		}
-		
+
 		modifier = {
 			factor = 1.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13016"
 		random_owned = {
@@ -437,7 +437,7 @@ country_event = {
 		}
 	}
 }
-	
+
 
 #Foreign Missionaries
 country_event = {
@@ -445,10 +445,10 @@ country_event = {
 	title = "EVTNAME13020"
 	desc = "EVTDESC13020"
 	picture = "missionaries"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -464,7 +464,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 240
 		modifier = {
@@ -512,7 +512,7 @@ country_event = {
 			num_of_ports = 50
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13020"
 		random_owned = {
@@ -540,7 +540,7 @@ country_event = {
 			factor = 90
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13020"
 		random_country = {
@@ -625,9 +625,9 @@ country_event = {
 	news_desc_medium = "EVTDESC13021_NEWS_MEDIUM"
 	news_desc_short = "EVTDESC13021_NEWS_SHORT"
 	picture = "missionaries"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13021"
 		relation = { who = FROM value = -25 }
@@ -670,7 +670,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13021"
 		random_owned = {
@@ -686,7 +686,7 @@ country_event = {
 		}
 		random_owned = {
 			limit = {
-				owner = { 
+				owner = {
 					is_greater_power = no
 					is_secondary_power = no
 				}
@@ -705,10 +705,10 @@ country_event = {
 	title = "EVTNAME13030"
 	desc = "EVTDESC13030"
 	picture = "bazaar"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -726,7 +726,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 240
 		modifier = {
@@ -762,7 +762,7 @@ country_event = {
 			pre_indust = yes_pre_indust
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13030"
 		random_owned = {
@@ -904,9 +904,9 @@ country_event = {
 	title = "EVTNAME13031"
 	desc = "EVTDESC13031"
 	picture = "Outside_influences"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13031"
 		casus_belli = {
@@ -955,7 +955,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13031"
 		relation = {
@@ -997,7 +997,7 @@ country_event = {
 			}
 			modifier = {
 				factor = 0.5
-				OR = {	
+				OR = {
 					government = colonial_company
 					government = absolute_monarchy
 					government = proletarian_dictatorship
@@ -1015,10 +1015,10 @@ country_event = {
 	title = "EVTNAME13040"
 	desc = "EVTDESC13040"
 	picture = "bazaar"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = {
@@ -1029,7 +1029,7 @@ country_event = {
 		civilized = no
 		has_country_modifier = western_influences
 	}
-	
+
 	mean_time_to_happen = {
 		months = 100
 		modifier = {
@@ -1075,7 +1075,7 @@ country_event = {
 			num_of_ports = 50
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13040"
 		random_owned = {
@@ -1125,10 +1125,10 @@ country_event = {
 	title = "EVTNAME13050"
 	desc = "EVTDESC13050"
 	picture = "Opium"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -1139,7 +1139,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 60
 		modifier = {
@@ -1160,13 +1160,13 @@ country_event = {
 			factor = 1.2
 			part_of_sphere = no
 		}
-		
+
 		modifier = {
 			factor = 3.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13050"
 		random_owned = {
@@ -1191,7 +1191,7 @@ country_event = {
 			factor = 70
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13050"
 		add_country_modifier = {
@@ -1202,7 +1202,7 @@ country_event = {
 			factor = 20
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTC13050"
 		random_owned = {
@@ -1277,7 +1277,7 @@ country_event = {
 					}
 				}
 			}
-			relation = { 
+			relation = {
 				who = THIS
 				value = -25
 			}
@@ -1294,10 +1294,10 @@ country_event = {
 	title = "EVTNAME13051"
 	desc = "EVTDESC13051"
 	picture = "Opium"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -1309,7 +1309,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 80
 		modifier = {
@@ -1356,13 +1356,13 @@ country_event = {
 			factor = 0.9
 			num_of_ports = 50
 		}
-		
+
 		modifier = {
 			factor = 1.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13051"
 		random_owned = {
@@ -1389,7 +1389,7 @@ country_event = {
 			factor = 60
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13051"
 		prestige = -3
@@ -1425,14 +1425,14 @@ province_event = {
 	id = 13055
 	title = "EVTNAME13055"
 	desc = "EVTDESC13055"
-	
+
 	trigger = {
 		port = yes
 		owner = {
 			civilized = no
-			NOT = { 
+			NOT = {
 				OR = {
-					tag = EIC 
+					tag = EIC
 					has_country_flag = spectator
 				}
 			}
@@ -1443,7 +1443,7 @@ province_event = {
 		NOT = { has_province_modifier = local_opium_habit }
 		NOT = { has_province_modifier = boxer_presence }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 90
 		modifier = {
@@ -1456,13 +1456,13 @@ province_event = {
 			factor = 0.8
 			has_province_modifier = foreign_smugglers
 		}
-		
+
 		modifier = {
 			factor = 1.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13055"
 		add_province_modifier = {
@@ -1532,7 +1532,7 @@ province_event = {
 					}
 				}
 			}
-			relation = { 
+			relation = {
 				who = THIS
 				value = -25
 			}
@@ -1548,15 +1548,15 @@ province_event = {
 	id = 13060
 	title = "EVTNAME13060"
 	desc = "EVTDESC13060"
-	
+
 	trigger = {
 		NOT = { port = yes }
 		owner = {
 			civilized = no
 			NOT = { number_of_states = 5 }
-			NOT = { 
+			NOT = {
 				OR = {
-					tag = EIC 
+					tag = EIC
 					has_country_flag = spectator
 				}
 			}
@@ -1567,7 +1567,7 @@ province_event = {
 		NOT = { has_province_modifier = local_opium_habit }
 		NOT = { has_province_modifier = boxer_presence }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 120
 		modifier = {
@@ -1584,13 +1584,13 @@ province_event = {
 			factor = 5
 			average_militancy = 5
 		}
-		
+
 		modifier = {
 			factor = 1.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13060"
 		add_province_modifier = {
@@ -1601,7 +1601,7 @@ province_event = {
 			factor = 90
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13060"
 		any_pop = {
@@ -1655,7 +1655,7 @@ province_event = {
 					}
 				}
 			}
-			relation = { 
+			relation = {
 				who = THIS
 				value = -40
 			}
@@ -1670,7 +1670,7 @@ province_event = {
 	id = 13061
 	title = "EVTNAME13060"
 	desc = "EVTDESC13061"
-	
+
 	trigger = {
 		NOT = { port = yes }
 		owner = {
@@ -1678,7 +1678,7 @@ province_event = {
 			number_of_states = 5
 			NOT = {
 				OR = {
-					tag = EIC 
+					tag = EIC
 					has_country_flag = spectator
 				}
 			}
@@ -1689,7 +1689,7 @@ province_event = {
 		NOT = { has_province_modifier = local_opium_habit }
 		NOT = { has_province_modifier = boxer_presence }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 240
 		modifier = {
@@ -1712,13 +1712,13 @@ province_event = {
 			factor = 5
 			average_militancy = 5
 		}
-		
+
 		modifier = {
 			factor = 1.5
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13060"
 		state_scope = {
@@ -1733,7 +1733,7 @@ province_event = {
 			factor = 90
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13060"
 		any_pop = {
@@ -1802,7 +1802,7 @@ province_event = {
 					}
 				}
 			}
-			relation = { 
+			relation = {
 				who = THIS
 				value = -40
 			}
@@ -1819,17 +1819,17 @@ country_event = {
 	title = "EVTNAME13065"
 	desc = "EVTDESC13065"
 	picture = "asian_administration"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		any_owned_province = {
 			has_province_modifier = local_opium_habit
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 60
 		modifier = {
@@ -1859,7 +1859,7 @@ country_event = {
 			has_country_modifier = lin_zexu
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13065"
 		random_state = {
@@ -1890,7 +1890,7 @@ country_event = {
 			factor = 75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13065"
 		prestige = -5
@@ -1916,19 +1916,19 @@ country_event = {
 	title = "EVTNAME13070"
 	desc = "EVTDESC13070"
 	picture = "explorers"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		any_owned_province = { has_province_modifier = foreign_trading_post }
 		NOT = { has_country_modifier = sayings_of_the_dutch }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
-		
+
 		modifier = {
 			factor = 0.9
 			plurality = 5
@@ -1950,7 +1950,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13070"
 		add_country_modifier = {
@@ -1966,10 +1966,10 @@ country_event = {
 	title = "EVTNAME13080"
 	desc = "EVTDESC13080"
 	picture = "Outside_influences"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = {
@@ -1980,7 +1980,7 @@ country_event = {
 		civilized = no
 		NOT = { has_country_flag = gave_up_2nd_opium }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 100
 		modifier = {
@@ -2008,7 +2008,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13080"
 		random_state = {
@@ -2028,7 +2028,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13080"
 		treasury = -5000
@@ -2049,7 +2049,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTC13080"
 		random_owned = {
@@ -2074,13 +2074,13 @@ country_event = {
 	picture = "bazaar"
 
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = { has_province_modifier = foreign_trading_post }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
 		modifier = {
@@ -2112,7 +2112,7 @@ country_event = {
 			average_militancy = 5
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13090"
 		years_of_research = 0.1
@@ -2131,9 +2131,9 @@ province_event = {
 
 	trigger = {
 		owner = {
-			NOT = { 
+			NOT = {
 				OR = {
-					tag = EIC 
+					tag = EIC
 					has_country_flag = spectator
 				}
 			}
@@ -2187,7 +2187,7 @@ province_event = {
 			owner = { civilization_progress = 0.75 }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13100"
 		state_scope = {
@@ -2213,17 +2213,17 @@ country_event = {
 	title = "EVTNAME13110"
 	desc = "EVTDESC13110"
 	picture = "Western_education"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		civilized = no
 		has_country_modifier = western_influences
 		NOT = { has_country_flag = princes_recieve_foreign_education }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 300
 		modifier = {
@@ -2257,7 +2257,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13110"
 		set_country_flag = princes_recieve_foreign_education
@@ -2278,10 +2278,10 @@ country_event = {
 	news_desc_medium = "EVTDESC13120_NEWS_MEDIUM"
 	news_desc_short = "EVTDESC13120_NEWS_SHORT"
 	picture = "Western_education"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		has_country_flag = princes_recieve_foreign_education
@@ -2300,13 +2300,13 @@ country_event = {
 	mean_time_to_happen = {
 		months = 12
 	}
-	
+
 	option = {
 		name = "EVTOPTA13120"
 		years_of_research = 0.1
 		set_country_flag = educated_princes_refused
 	}
-	
+
 	option = {
 		name = "EVTOPTB13120"
 		any_pop = {
@@ -2319,7 +2319,7 @@ country_event = {
 		}
 		political_reform = no_slavery
 		prestige = 5
-		
+
 	}
 }
 
@@ -2329,10 +2329,10 @@ country_event = {
 	title = "EVTNAME13130"
 	desc = "EVTDESC13130"
 	picture = "Military_reform"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -2342,7 +2342,7 @@ country_event = {
 			NOT = { has_province_modifier = boxer_presence }
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 120
 		modifier = {
@@ -2413,7 +2413,7 @@ country_event = {
 			factor = 80
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13130"
 		random_country = {
@@ -2443,10 +2443,10 @@ country_event = {
 	title = "EVTNAME13140"
 	desc = "EVTDESC13140"
 	picture = "arrested"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		war = yes
@@ -2454,7 +2454,7 @@ country_event = {
 			has_province_modifier = european_military_mission
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 12
 		modifier = {
@@ -2480,7 +2480,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13140"
 		random_owned = {
@@ -2497,12 +2497,12 @@ province_event = {
 	id = 13150
 	title = "EVTNAME13150"
 	desc = "EVTDESC13150"
-	
+
 	trigger = {
 		owner = {
-			NOT = { 
+			NOT = {
 				OR = {
-					tag = EIC 
+					tag = EIC
 					has_country_flag = spectator
 				}
 			}
@@ -2552,7 +2552,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13150"
 		remove_province_modifier = european_military_mission
@@ -2569,7 +2569,7 @@ province_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13150"
 		any_pop = {
@@ -2592,10 +2592,10 @@ country_event = {
 	title = "EVTNAME13160"
 	desc = "EVTDESC13160"
 	picture = "arrested"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = {
@@ -2611,7 +2611,7 @@ country_event = {
 		is_vassal = no
 		NOT = { has_country_flag = gave_up_2nd_opium }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
 		modifier = {
@@ -2631,7 +2631,7 @@ country_event = {
 			prestige = 50
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13160"
 		random_country = {
@@ -2709,7 +2709,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13160"
 		random_owned = {
@@ -2804,9 +2804,9 @@ country_event = {
 	title = "EVTNAME13170"
 	desc = "EVTDESC13170"
 	picture = "Outside_influences"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13170"
 		prestige = 5
@@ -2846,7 +2846,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13170"
 		prestige = -5
@@ -2891,9 +2891,9 @@ country_event = {
 	title = "EVTNAME13180"
 	desc = "EVTDESC13180"
 	picture = "Outside_influences"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13180"
 		prestige = 3
@@ -2910,10 +2910,10 @@ country_event = {
 	title = "EVTNAME13185"
 	desc = "EVTDESC13185"
 	picture = "India"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		civilized = no
@@ -2925,7 +2925,7 @@ country_event = {
 			has_province_modifier = legation_quarter
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 120
 		modifier = {
@@ -2949,7 +2949,7 @@ country_event = {
 			pre_indust = yes_pre_indust
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13185"
 		years_of_research = 0.1
@@ -3010,9 +3010,9 @@ country_event = {
 		ai_chance = {
 			factor = 80
 		}
-			
+
 	}
-	
+
 	option = {
 		name = "EVTOPTB13185"
 		prestige = -3
@@ -3028,9 +3028,9 @@ country_event = {
 	title = "EVTNAME13186"
 	desc = "EVTDESC13186"
 	picture = "banquet"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13186"
 		treasury = -25000
@@ -3044,7 +3044,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13186"
 		diplomatic_influence = { who = FROM value = 20 }
@@ -3053,7 +3053,7 @@ country_event = {
 			factor = 25
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTC13186"
 		prestige = -3
@@ -3061,7 +3061,7 @@ country_event = {
 			factor = 0
 		}
 	}
-}	
+}
 
 #Military Reform
 country_event = {
@@ -3069,16 +3069,16 @@ country_event = {
 	title = "EVTNAME13190"
 	desc = "EVTDESC13190"
 	picture = "Military_reform"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		has_country_modifier = western_influences
 		NOT = { has_country_modifier = military_reform }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 1000
 		modifier = {
@@ -3116,7 +3116,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13190"
 		add_country_modifier = {
@@ -3138,7 +3138,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13190"
 		prestige = 10
@@ -3157,10 +3157,10 @@ country_event = {
 	title = "EVTNAME13200"
 	desc = "EVTDESC13200"
 	picture = "Military_reform"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		OR = {
@@ -3190,7 +3190,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13200"
 		random_owned = {
@@ -3220,7 +3220,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13200"
 		any_pop = {
@@ -3256,9 +3256,9 @@ country_event = {
 	news_desc_medium = "EVTDESC13201_NEWS_MEDIUM"
 	news_desc_short = "EVTDESC13201_NEWS_SHORT"
 	picture = "Outside_influences"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13201"
 		leave_alliance = FROM
@@ -3300,7 +3300,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13201"
 		diplomatic_influence = {
@@ -3325,9 +3325,9 @@ country_event = {
 	title = "EVTNAME13202"
 	desc = "EVTDESC13202"
 	picture = "genevaconvention"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13202"
 		badboy = 2
@@ -3423,7 +3423,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13202"
 		diplomatic_influence = {
@@ -3454,16 +3454,16 @@ country_event = {
 	title = "EVTNAME13210"
 	desc = "EVTDESC13210"
 	picture = "Western_education"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		has_country_modifier = western_influences
 		NOT = { has_country_modifier = educational_reform }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 300
 		modifier = {
@@ -3475,7 +3475,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13210"
 		add_country_modifier = {
@@ -3489,7 +3489,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13210"
 		prestige = 5
@@ -3508,10 +3508,10 @@ country_event = {
 	title = "EVTNAME13220"
 	desc = "EVTDESC13220"
 	picture = "cairo"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = {
@@ -3523,7 +3523,7 @@ country_event = {
 		is_vassal = no
 		NOT = { has_country_flag = gave_up_2nd_opium }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 100
 		modifier = {
@@ -3563,7 +3563,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13220"		#Set up a legation quarter
 		capital_scope = {
@@ -3582,7 +3582,7 @@ country_event = {
 			factor = 90
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13220"		#The foreigners have nothing to offer
 		random_country = {
@@ -3690,10 +3690,10 @@ country_event = {
 	news_desc_medium = "EVTDESC13230_NEWS_MEDIUM"
 	news_desc_short = "EVTDESC13230_NEWS_SHORT"
 	picture = "Outside_influences"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 		}
 		any_owned_province = {
@@ -3703,7 +3703,7 @@ country_event = {
 		}
 		NOT = { has_country_flag = gave_up_2nd_opium }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
 		modifier = {
@@ -3739,7 +3739,7 @@ country_event = {
 			civilization_progress = 0.75
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13230"
 		capital_scope = {
@@ -3755,7 +3755,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13230"
 		random_country = {
@@ -3828,7 +3828,7 @@ country_event = {
 		}
 		prestige = -5
 	}
-	
+
 	option = {
 		name = "EVTOPTC13230"
 		random_country = {
@@ -3850,10 +3850,10 @@ country_event = {
 	title = "EVTNAME13240"
 	desc = "EVTDESC13240"
 	picture = "Opiumwar"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
 			has_country_flag = spectator
 			has_country_flag = treaty_of_macao
 		}
@@ -3867,11 +3867,11 @@ country_event = {
 		}
 		has_country_modifier = trade_restrictions
 	}
-	
+
 	mean_time_to_happen = {
 		months = 100
 	}
-	
+
 	option = {
 		name = "EVTOPTA13240"
 		random_country = {
@@ -3937,7 +3937,7 @@ country_event = {
 			country_event = 13250
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13240"
 		random_owned = {
@@ -3960,9 +3960,9 @@ country_event = {
 	title = "EVTNAME13250"
 	desc = "EVTDESC13250"
 	picture = "Opiumwar"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13250"
 		FROM = {
@@ -3977,7 +3977,7 @@ country_event = {
 			country_event = 13260
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13250"
 		prestige = -5
@@ -3990,14 +3990,14 @@ country_event = {
 	title = "EVTNAME13260"
 	desc = "EVTDESC13260"
 	picture = "Outside_influences"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13260"
 		remove_country_modifier = trade_restrictions
 	}
-	
+
 	option = {
 		name = "EVTOPTB13260"
 		FROM = {
@@ -4020,10 +4020,10 @@ country_event = {
 	news_desc_medium = "EVTDESC13270_NEWS_MEDIUM"
 	news_desc_short = "EVTDESC13270_NEWS_SHORT"
 	picture = "Opiumwar"
-	
-	
+
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13270"
 		prestige = -5
@@ -4063,10 +4063,10 @@ country_event = {
 	title = "EVTNAME13280"
 	desc = "EVTDESC13280"
 	picture = "Outside_influences"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		civilized = no
@@ -4074,11 +4074,11 @@ country_event = {
 		civilization_progress = 0.1
 		any_owned = { any_pop = { type = aristocrats OR = { militancy = 3 consciousness = 6 } } }
 	}
-	
+
 	mean_time_to_happen = {
 		months = 200
 	}
-	
+
 	option = {
 		name = "EVTOPTA13280"
 		random_owned = {
@@ -4101,17 +4101,17 @@ country_event = {
 	title = "EVTNAME13290"
 	desc = "EVTDESC13290"
 	picture = "Opiumwar"
-	
+
 	trigger = {
-		NOT = { 
-			tag = EIC 
+		NOT = {
+			tag = EIC
  has_country_flag = spectator
 		}
 		civilized = no
 		has_country_modifier = uncivilized_isolationism
 		has_recently_lost_war = yes
 	}
-	
+
 	mean_time_to_happen = {
 		months = 100
 		modifier = {
@@ -4131,7 +4131,7 @@ country_event = {
 			average_militancy = 3
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13290"
 		years_of_research = 0.4
@@ -4145,7 +4145,7 @@ country_event = {
 			militancy = 1
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB13290"
 		years_of_research = 0.2
@@ -4159,9 +4159,9 @@ country_event = {
 	title = "EVTNAME13350"
 	desc = "EVTDESC13350"
 	picture = "elephant"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13350"
 		relation = {
@@ -4182,15 +4182,15 @@ country_event = {
 	news_desc_short = "EVTDESC13355_NEWS_SHORT"
 	major = yes
 	picture = "cityfire"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13355"
 		prestige = -25
 		war_exhaustion = 5
-		1612 = { 
-			clr_province_flag = summer_palace 
+		1612 = {
+			clr_province_flag = summer_palace
 			any_pop = {
 				reduce_pop = 0.99
 			}
@@ -4203,9 +4203,9 @@ country_event = {
 	id = 13357
 	title = "EVTNAME13357"
 	desc = "EVTDESC13357"
-	
+
 	picture = "Rebellion"
-	
+
 	trigger = {
 		OR = {
 			vassal_of = EIC
@@ -4257,7 +4257,7 @@ country_event = {
 			tag = CRL
 		}
 	}
-	
+
 	mean_time_to_happen = {
 		months = 600
 		modifier = {
@@ -4315,7 +4315,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA13357"
 		tech_school = unciv_tech_school
@@ -4352,12 +4352,12 @@ country_event = {
 	news = yes
 	news_desc_long = "EVTDESC13358_NEWS_LONG"
 	news_desc_medium = "EVTDESC13358_NEWS_MEDIUM"
-	news_desc_short = "EVTDESC13358_NEWS_SHORT"	
-	
+	news_desc_short = "EVTDESC13358_NEWS_SHORT"
+
 	picture = "india"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA13358"
 		prestige = 5
@@ -4387,10 +4387,10 @@ country_event = {
 			}
 		}
 		set_global_flag = doctrine_of_lapse_has_been_used
-		
+
 		ai_chance = { factor = 100 }
 	}
-	
+
 	option = {
 		name = "EVTOPTB13358"
 		prestige = -2
@@ -4415,7 +4415,7 @@ country_event = {
 	id = 90910
 
 	is_triggered_only = yes
-	
+
 	trigger = {
 		NOT = {
 			tag = QNG
@@ -4437,13 +4437,13 @@ country_event = {
 		}
 	}
 
-	option = {				
+	option = {
 		name = "EVTOPTA90910"
 		prestige = 5
 		tech_school = traditional_academic
 		clr_country_flag = lacking_writing_system
 		random_owned = { limit = { owner = { ai = yes } } owner = { add_country_modifier = { name = law_changed_by_force duration = 3 } } }
-		random_owned = { 
+		random_owned = {
 			limit = { owner = { has_country_flag = activate_experimental_railroad } NOT = { experimental_railroad = 1 } }
 			owner = { activate_technology = experimental_railroad  clr_country_flag = activate_experimental_railroad }
 		}
@@ -4490,19 +4490,19 @@ country_event = {
 	id = 90950
 
 	is_triggered_only = yes
-	
+
 	trigger = {
 		#
 	}
 
-	option = {				
+	option = {
 		name = "EVTOPTA90950"
 		random_country = { limit = { tag = FROM is_greater_power = yes } add_casus_belli = { target = THIS type = humiliate months = 12 } }
 		random_country = { limit = { tag = FROM is_greater_power = no } add_casus_belli = { target = THIS type = make_puppet months = 12 } }
 		relation = { who = FROM value = -100 }
 	}
-	
-	option = {				
+
+	option = {
 		name = "EVTOPTB90950"
 		relation = { who = FROM value = 100 }
 		rich_strata = { militancy = 3 consciousness = 6 }
@@ -4515,9 +4515,9 @@ country_event = {
 	title = "EVTNAME90953"
 	desc = "EVTDESC90953"
 	picture = "arab_revolt"
-	
+
 	fire_only_once = yes
-	
+
 	trigger = {
 			1714 = { empty = no }
 			1718 = { empty = no }
@@ -4543,28 +4543,22 @@ province_event = {
 	id = 90954
 	title = "EVTNAME90954"
 	desc = "EVTDESC90954"
-		
+
 	trigger = {
 		OR = {
-			province_id = 1498
-			province_id = 1496
-			AND = {
-				province_id = 1569
-				NOT = { total_pops = 30000 }
-			}
-			AND = {
-				province_id = 1566
-				NOT = { total_pops = 30000 }
-			}
-			AND = {
-				province_id = 2632
-				NOT = { total_pops = 30000 }
-				NOT = { 1496 = { trade_goods = precious_goods } }
-			}
-			AND = {
-				province_id = 1538
-				NOT = { total_pops = 90000 }
-			}
+			province_id = 1481 # Port Arthur
+			province_id = 1482 # Fuzhou
+			province_id = 1496 # Hong Kong
+			province_id = 1498 # Macao
+			province_id = 1499 # Hainan
+			province_id = 1538 # Shanghai
+			province_id = 1566 # Qingdao
+			province_id = 1569 # Weihaiwei
+			province_id = 1606 # Jiaxing
+			province_id = 1608 # Ningbo
+			province_id = 2632 # Kwangchowan
+			province_id = 3249 # Old Tianjin
+			province_id = 3326 # San Mun
 		}
 		port = yes
 		NOT = { has_province_modifier = treaty_port }
@@ -4573,19 +4567,15 @@ province_event = {
 			civilized = yes
 			NOT = { is_culture_group = east_asian }
 			NOT = { is_culture_group = far_east_asian }
-			}
-		NOT = { any_neighbor_province = { owned_by = THIS } }
-		any_neighbor_province = { owner = { capital_scope = {continent = asia } } }
+		}
 	}
-	
-	mean_time_to_happen = { months = 8 }
+
+	mean_time_to_happen = { months = 1 }
 
 	option = {
 		name = "EVTOPTA90954"
-		trade_goods = precious_goods
 		any_pop = { limit = { is_culture_group = east_asian } reduce_pop = 1.1 }
 		add_province_modifier = { name = treaty_port duration = -1 }
-		naval_base = 1
 	}
 }
 
@@ -4594,7 +4584,7 @@ province_event = {
 	id = 90955
 	title = "EVTNAME90954"
 	desc = "EVTDESC90955"
-		
+
 	trigger = {
 		owner = { capital_scope = { continent = asia } }
 		OR = {
@@ -4616,7 +4606,7 @@ province_event = {
 	}
 
 	mean_time_to_happen = { months = 1 }
-	
+
 	option = {
 		name = "EVTOPTA90955"
 		add_province_modifier = { name = treaty_port duration = -1 }
@@ -4634,13 +4624,13 @@ province_event = {
 	id = 90956
 	title = "EVTNAME90956"
 	desc = "EVTDESC90956"
-		
+
 	trigger = {
 		province_id = 1496
 		1496 = { trade_goods = precious_goods }
 		1496 = { owner = { civilized = yes capital_scope = { NOT = {continent = asia } } } }
 	}
-	
+
 	fire_only_once = yes
 
 	mean_time_to_happen = { days = 1 }
@@ -4654,19 +4644,19 @@ province_event = {
 			40 = { 1497 = { any_pop = { limit = { type = bureaucrats culture = yue } move_pop = 1496 } } }
 			}
 		}
-	
+
 	option = {
 		name = "EVTOPTA90956"
-		
+
 		any_pop = {
 			limit = {
 				culture = yue
 				type = serfs
 			}
-			pop_type = labourers	
+			pop_type = labourers
 			reduce_pop = 0.9
 		}
-		
+
 		any_pop = {
 			limit = {
 				culture = hakka
@@ -4674,7 +4664,7 @@ province_event = {
 			reduce_pop = 2.5
 		}
 	}
-		
+
 }
 
 
@@ -4684,57 +4674,20 @@ country_event = {
 	title = "EVTNAME90957"
 	desc = "EVTDESC90957"
 	picture = "central_asian_tribes"
-	
+
 	trigger = {
 		tag = AFG
 		owns = 1211
 		BUK = { exists = no }
 	}
-	
+
 	fire_only_once = yes
 
 	mean_time_to_happen = { months = 12 }
-	
+
 	option = {
 		name = "EVTOPTA90957"
 		1211 = { remove_core = BUK }
-	}
-}
-
-#Treaty Ports
-province_event = {
-	id = 90958
-	title = "EVTNAME90954"
-	desc = "EVTDESC90954"
-		
-	trigger = {
-		OR = {
-			AND = {
-				is_core = CHI
-				NOT = { province_id = 1498 }
-				NOT = { province_id = 1496 }
-				NOT = { province_id = 1569 }
-				NOT = { province_id = 1566 }
-			}
-			AND = { province_id = 1569 total_pops = 30000 }
-			AND = { province_id = 1566 total_pops = 30000 }
-		}
-		port = yes
-		NOT = { has_province_modifier = treaty_port }
-		owner = {
-			civilized = yes
-			NOT = { is_culture_group = east_asian }
-			NOT = { is_culture_group = far_east_asian }
-		}
-		NOT = { any_neighbor_province = { owned_by = THIS } }
-		any_neighbor_province = { owner = { capital_scope = {continent = asia } } }
-	}
-	
-	mean_time_to_happen = { months = 8 }
-
-	option = {
-		name = "EVTOPTA90954"
-		add_province_modifier = { name = treaty_port duration = -1 }
 	}
 }
 
@@ -4745,7 +4698,7 @@ country_event = {
 	title = "EVTNAME90959"
 	desc = "EVTDESC90959"
 	picture = "boxers"
-		
+
 	is_triggered_only = yes
 
 	immediate = {
@@ -4766,9 +4719,9 @@ country_event = {
 			}
 			owner = { add_country_modifier = { name = isolationist_foreign_naval_schools duration = -1 } }
 		}
-		
+
 		random_owned = {
-			limit = { 
+			limit = {
 				owner = {
 					OR = {
 						is_culture_group = east_asian
@@ -4785,9 +4738,9 @@ country_event = {
 			owner = { add_country_modifier = { name = isolationist_foreign_officers duration = -1 } }
 		}
 
-		
+
 		random_owned = {
-			limit = { 
+			limit = {
 				owner = {
 					OR = {
 						is_culture_group = east_asian
@@ -4803,9 +4756,9 @@ country_event = {
 			}
 			owner = { add_country_modifier = { name = isolationist_foreign_naval_officers duration = -1 } }
 		}
-		
+
 		random_owned = {
-			limit = { 
+			limit = {
 				owner = {
 					OR = {
 						is_culture_group = east_asian
@@ -4821,30 +4774,30 @@ country_event = {
 			}
 			owner = { add_country_modifier = { name = isolationist_foreign_training duration = -1 } }
 		}
-		
+
 		random_owned = {
-			limit = { 
+			limit = {
 				owner = {
 					has_country_modifier = corrupt_army
 					OR = {
 						foreign_officers = yes_foreign_officers
-						foreign_training = yes_foreign_training						
-					} 
+						foreign_training = yes_foreign_training
+					}
 				}
 			}
 			owner = { remove_country_modifier = corrupt_army }
 		}
-		
+
 		random_owned = {
-			limit = { 
+			limit = {
 				owner = {
 					has_country_modifier = assegai
 					OR = {
 						foreign_officers = yes_foreign_officers
-						foreign_training = yes_foreign_training	
+						foreign_training = yes_foreign_training
 						foreign_artillery = yes_foreign_artillery
 						foreign_weapons = yes_foreign_weapons
-					} 
+					}
 				}
 			}
 			owner = { remove_country_modifier = assegai }
@@ -4880,7 +4833,7 @@ country_event = {
 			}
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA90959"
 	}
@@ -4892,28 +4845,28 @@ country_event = {
 	title = "EVTNAME110073"
 	desc = "EVTDESC110073"
 	picture = "ALL_golden_stool"
-	
+
 	trigger = {
 		has_global_flag = berlin_conference
 		nationalism_n_imperialism = 1
 		capital_scope = { continent = europe }
-		OR = { 
+		OR = {
 			is_greater_power = yes
 			is_secondary_power = yes
 		}
 		ASH = { all_core = { owned_by = THIS } }
 	}
-		
-	fire_only_once = yes	
-	
-	mean_time_to_happen = { 
-		months = 40 
+
+	fire_only_once = yes
+
+	mean_time_to_happen = {
+		months = 40
 		modifier = {
 			factor = 0.3
 			year = 1900
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTA110073" #This will make a nice trinket!
 		prestige = 15
@@ -4939,7 +4892,7 @@ country_event = {
 		}
 		ai_chance = { factor = 100 }
 	}
-	
+
 	option = {
 		name = "EVTOPTB110073" #Let them have it.
 		badboy = -1
@@ -4966,9 +4919,9 @@ country_event = {
 	title = "EVTNAME90960"
 	desc = "EVTDESC90960"
 	picture = "missionaries"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA90960" #Catholic
 		set_country_flag = change_to_catholic
@@ -4980,7 +4933,7 @@ country_event = {
 						is_greater_power = yes
 						has_country_flag = catholic_country
 					}
-					AND = { 
+					AND = {
 						primary_culture = french
 						is_greater_power = yes
 						capital = 425
@@ -4994,7 +4947,7 @@ country_event = {
 			modifier = { factor = 100 any_neighbor_country = { is_greater_power = yes has_country_flag = catholic_country } }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB90960" #Protestant
 		set_country_flag = change_to_protestant
@@ -5017,7 +4970,7 @@ country_event = {
 			modifier = { factor = 100 any_neighbor_country = { is_greater_power = yes has_country_flag = protestant_country } }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTC90960" #Orthodox
 		set_country_flag = change_to_orthodox
@@ -5039,7 +4992,7 @@ country_event = {
 			modifier = { factor = 100 any_neighbor_country = { is_greater_power = yes has_country_flag = orthodox_country } }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTD90960" #Sunni
 		set_country_flag = change_to_sunni
@@ -5061,13 +5014,13 @@ country_event = {
 			modifier = { factor = 100 any_neighbor_country = { is_greater_power = yes has_country_flag = sunni_country } }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTE90960" #Nevermind
 		prestige = 3
 		ai_chance = { factor = 0 }
 	}
-	
+
 }
 
 #Requesting Foreign Missionaries - GPs decide what to do
@@ -5076,9 +5029,9 @@ country_event = {
 	title = "EVTNAME90961"
 	desc = "EVTDESC90961"
 	picture = "missionaries"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA90961" #Send the missionaries
 		relation = { who = FROM value = 25 }
@@ -5099,7 +5052,7 @@ country_event = {
 			modifier = { factor = 0.5 FROM = { badboy = 0.5 } }
 		}
 	}
-	
+
 	option = {
 		name = "EVTOPTB90961" #Send the missionaries
 		relation = { who = FROM value = -25 }
@@ -5116,9 +5069,9 @@ country_event = {
 	title = "EVTNAME90962"
 	desc = "EVTDESC90962"
 	picture = "missionaries"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA90962"
 		set_country_flag = missionary_activity
@@ -5171,9 +5124,9 @@ country_event = {
 	title = "EVTNAME90963"
 	desc = "EVTDESC90963"
 	picture = "missionaries"
-	
+
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPTA90963"
 		clr_country_flag = change_to_sunni
@@ -5197,9 +5150,9 @@ country_event = {
 	id = 99907
 	title = "EVTNAME99907"
 	desc = "EVTDESC99907"
-	fire_only_once = yes	
+	fire_only_once = yes
 	major = yes
-	
+
 	trigger = {
 		tag = ENG
 		year = 1847
@@ -5214,14 +5167,14 @@ country_event = {
 		relation = {
 			who = GRE
 			value = -15
-		} 
+		}
 		GRE = {
 			country_event = { id=99908 days=60 }
 		}
 		set_country_flag = don_pacifico
 		ai_chance = { factor = 80 }
 	}
-	
+
 	option = {
 		name = "EVTOPTB99907"
 		prestige = -10
@@ -5229,7 +5182,7 @@ country_event = {
 			militancy  = 0.01
 		}
 		set_country_flag = don_pacifico
-		
+
 		ai_chance = { factor = 20 }
 	}
 }
@@ -5241,7 +5194,7 @@ country_event = {
 	desc = "EVTDESC99908"
 	is_triggered_only = yes
 	fire_only_once = yes
-	
+
 	option = {
 		name = "EVTOPTA99908" #No
 		prestige = 10
@@ -5251,14 +5204,14 @@ country_event = {
 		relation = {
 			who = ENG
 			value = -15
-		} 
+		}
 		relation = {
 			who = POR
 			value = -15
-		} 
+		}
 		ai_chance = { factor = 0.8 }
 	}
-	
+
 		option = {
 		name = "EVTOPTB99908" #Yes
 		prestige = -10
@@ -5268,11 +5221,11 @@ country_event = {
 		relation = {
 			who = ENG
 			value = 20
-		} 
+		}
 		relation = {
 			who = POR
 			value = 20
-		} 
+		}
 		ai_chance = { factor = 0.2 }
 		treasury = -1000
 	}
@@ -5284,7 +5237,7 @@ country_event = {
 	title = "EVTNAME99909"
 	desc = "EVTDESC99909"
 	picture = "PDA_Refuse"
-	fire_only_once = yes	
+	fire_only_once = yes
 	is_triggered_only = yes
 
 	option = {
@@ -5293,13 +5246,13 @@ country_event = {
 		relation = {
 			who = GRE
 			value = -15
-		} 
+		}
 		GRE = {
 			country_event = { id=99911 days=60 } #Send Blockade
 		}
 		ai_chance = { factor = 1 }
 	}
-	
+
 	option = {
 		name = "EVTOPTB99909" #NoBlockade
 		prestige = -10
@@ -5314,23 +5267,23 @@ country_event = {
 	id = 99910
 	title = "EVTNAME99910"
 	desc = "EVTDESC99910"
-	fire_only_once = yes	
+	fire_only_once = yes
 	picture = "treaty"
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "EVTOPT99910"
 		prestige = 10
 		random_owned = {
 			limit = { exists = FRA }
 			owner = { relation = { who = FRA value = -15 } }
-		}	
+		}
 		random_owned = {
 			limit = { exists = BOR }
 			owner = { relation = { who = BOR value = -15 } 	 }
-		}		
-		relation = { who = PRU value = -15 } 		
-		relation = { who = POR value = 15 } 		
+		}
+		relation = { who = PRU value = -15 }
+		relation = { who = POR value = 15 }
 		POR = { treasury = 1000 }
 	}
 }
@@ -5341,7 +5294,7 @@ country_event = {
 	title = "EVTNAME99911"
 	desc = "EVTDESC99911"
 	picture = "PDA_Blockade"
-	fire_only_once = yes	
+	fire_only_once = yes
 	is_triggered_only = yes
 
 	option = {
@@ -5356,7 +5309,7 @@ country_event = {
 		}
 		ai_chance = { factor = 0.05 }
 	}
-	
+
 	option = {
 		name = "EVTOPTB99911"
 		prestige = -10
@@ -5394,7 +5347,7 @@ country_event = {
 	title = "Peaceful Annexation"
 	desc = EVTDESC9705979
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "Begin diplomatic annexation."
 		any_country = {
@@ -5418,27 +5371,27 @@ country_event = {
 		set_global_flag = no_incorp
 	}
 }
-	
+
 country_event = {
 	id = 5582701
 	title = "Annexed by Overlords"
 	desc = EVTDESC5582701
 	allow_multiple_instances = yes
 	is_triggered_only = yes
-	
+
 	option = {
 		name = "Ok."
 		any_country = {
 			limit = {
 				is_sphere_leader_of = THIS
 			}
-			country_event = 9972733 
+			country_event = 9972733
 		}
 		ai_chance = {
 			factor = 100
 		}
 	}
-	
+
 }
 
 country_event = {
@@ -5448,11 +5401,11 @@ country_event = {
 	allow_multiple_instances = yes
 	is_triggered_only = yes
 
-	
+
 	option = {
 		name = "Let's maintain the status quo."
 	}
-	
+
 	option = {
 		name = "Our rightful territory must be returned."
 		badboy = 3.5
@@ -5482,7 +5435,7 @@ country_event = {
 			who = FROM
 			value = -400
 		}
-					
+
 	}
 }
 

--- a/TGC/localisation/00_decisions.csv
+++ b/TGC/localisation/00_decisions.csv
@@ -2785,6 +2785,8 @@ fund_ZAN_rebels_title;Fund Rebels of Zanzibar;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
 fund_ZUL_rebels_desc;We have been contacted by members of the liberation movement of Zulu, currently living under the dominion of a neighbouring country. There is an opportunity to stir up sentiment among those living there so that they may rise up and weaken our enemy. There is, of course, a risk that our efforts could be discovered and bring war down upon us.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 fund_ZUL_rebels_title;Fund Rebels of Zulu;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 futile;Futile;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+fuzhou_treaty_port_desc;Fuzhou is an important port and trading city, as well as a large producer of tea. During the Ming dynasty, the legendary Admiral Zheng He and his treasure fleet sailed seven times from this city. It will further our Far East ambitions greatly to establish a treaty port there.;;;;;;;;;;;;;x
+fuzhou_treaty_port_title;The Fuzhou Treaty Port;;;;;;;;;;;;;x
 futile_desc;We have made our gesture of defiance against the greater powers. Now we must wait, lest we push our luck too far.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 gadsden_purchase_desc;Transportation and trade in the southwest would be greatly simplified if we could acquire the Mexican desert valley that runs just south of our Arizona Territory. In fact, it wouldn’t hurt to go ahead and acquire Lower California, as well. We could offer to purchase a bit more of Mexico’s land, bidding different sums depending on how much territory they were willing to part with.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 gadsden_purchase_title;Gadsden Purchase;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
@@ -4607,6 +4609,8 @@ samos_unite_with_greece_desc;Our little Island will never survive on its own. It
 samos_unite_with_greece_title;Join Greece;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 san_marino_question_desc;With the Formation of Italy at hand, Sammarinese independence has now come into question. We should negotiate with the new Italian state to recognize the independence of $COUNTRY$;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 san_marino_question_title;The San Marino Question;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+san_mun_treaty_port_desc;The San Mun bay is small and not very populous, but it will provide for an important port base in the Far East.;;;;;;;;;;;;;x
+san_mun_treaty_port_title;The San Mun Treaty Port;;;;;;;;;;;;;x
 sanctions_lifted_desc;After our defeat and the imposed restrictions in our nation’s military, the great powers are keener to lift up the trade restrictions they put in place.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 sanctions_lifted_title;Sanctions Lifted;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 sand_river_convention_desc;The Boers of the Transvaal are becoming increasingly resistant to colonial rule. The time has come to meet with them at Pretoria and discuss the terms of their independence—preferably subject to our conditions, which are that they abandon all laws allowing slavery and that our influence within their borders remain strong.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Removing duplicate event for treaty port modifier.
Adding France, England and Germany specific decisions for treaty ports to the disable colonial railroading setting.
Adding treaty port decisions for Fuzhou and San Mun.
Formatting.